### PR TITLE
Manual bump of Swashbuckle libs as they need to be done together

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "swashbuckle.aspnetcore.cli": {
-      "version": "7.2.0",
+      "version": "8.1.0",
       "commands": [
         "swagger"
       ],

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="7.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="8.1.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1,5 +1,5 @@
 ﻿{
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Trade Imports Data API",
     "description": "TBC",

--- a/tests/Api.IntegrationTests/OpenApi/OpenApiTests.Redoc_VerifyAsExpected.verified.txt
+++ b/tests/Api.IntegrationTests/OpenApi/OpenApiTests.Redoc_VerifyAsExpected.verified.txt
@@ -11,7 +11,18 @@
   },
   StatusCode: OK,
   ReasonPhrase: OK,
-  Headers: [],
+  Headers: [
+    {
+      Cache-Control: [
+        max-age=604800, private
+      ]
+    },
+    {
+      ETag: [
+        W/"s/7yFJ69eDl0FoFWeOg6AUJVF24="
+      ]
+    }
+  ],
   TrailingHeaders: [],
   RequestMessage: {
     Version: 1.1,


### PR DESCRIPTION
Dependabot cannot do these as they need to be done together but then they also impact tests due to changes.

Performing the upgrade manually in this PR.