### PR TITLE
Use local pinned version of csharpier

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,6 +8,13 @@
         "swagger"
       ],
       "rollForward": false
+    },
+    "csharpier": {
+      "version": "0.30.6",
+      "commands": [
+        "dotnet-csharpier"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,6 @@ RUN wget --secure-protocol=TLSv1_2 "https://github.com/daveshanley/vacuum/releas
 
 WORKDIR /src
 
-ENV PATH="$PATH:/root/.dotnet/tools"
-RUN dotnet tool install -g --allow-roll-forward csharpier
-
 COPY .config/dotnet-tools.json .config/dotnet-tools.json
 COPY .csharpierrc .csharpierrc
 COPY .vacuum.yml .vacuum.yml


### PR DESCRIPTION
Rather than install latest, use a pinned version of csharpier so we can keep local devs inline with version being used in the pipeline.