### PR TITLE
Split Domain from MongoDB references

### DIFF
--- a/Defra.TradeImportsDataApi.sln
+++ b/Defra.TradeImportsDataApi.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data", "src\Data\Data.cspro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain.csproj", "{9457F847-9127-466B-ADDA-99DE6F5FA38A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain.MongoDB.Tests", "tests\Domain.MongoDB.Tests\Domain.MongoDB.Tests.csproj", "{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{9457F847-9127-466B-ADDA-99DE6F5FA38A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9457F847-9127-466B-ADDA-99DE6F5FA38A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9457F847-9127-466B-ADDA-99DE6F5FA38A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,5 +66,6 @@ Global
 		{7B45D389-C533-43D5-8E04-ADC17FADC4D4} = {92349C3B-0C37-4727-ADAC-95748294D315}
 		{28337F7B-6FC1-41B0-8D55-2707408923E4} = {30577215-A7B4-4DBB-9F6B-38D2AA88E7E2}
 		{9457F847-9127-466B-ADDA-99DE6F5FA38A} = {30577215-A7B4-4DBB-9F6B-38D2AA88E7E2}
+		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58} = {92349C3B-0C37-4727-ADAC-95748294D315}
 	EndGlobalSection
 EndGlobal

--- a/Defra.TradeImportsDataApi.sln
+++ b/Defra.TradeImportsDataApi.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain.MongoDB.Tests", "tests\Domain.MongoDB.Tests\Domain.MongoDB.Tests.csproj", "{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain.MongoDB", "src\Domain.MongoDB\Domain.MongoDB.csproj", "{0C4ED0EE-75A3-40CC-AE6D-556215D90BA4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,10 @@ Global
 		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C4ED0EE-75A3-40CC-AE6D-556215D90BA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C4ED0EE-75A3-40CC-AE6D-556215D90BA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C4ED0EE-75A3-40CC-AE6D-556215D90BA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C4ED0EE-75A3-40CC-AE6D-556215D90BA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -67,5 +73,6 @@ Global
 		{28337F7B-6FC1-41B0-8D55-2707408923E4} = {30577215-A7B4-4DBB-9F6B-38D2AA88E7E2}
 		{9457F847-9127-466B-ADDA-99DE6F5FA38A} = {30577215-A7B4-4DBB-9F6B-38D2AA88E7E2}
 		{CDEC7EC0-D0DA-474A-A327-5D27CDFEAD58} = {92349C3B-0C37-4727-ADAC-95748294D315}
+		{0C4ED0EE-75A3-40CC-AE6D-556215D90BA4} = {30577215-A7B4-4DBB-9F6B-38D2AA88E7E2}
 	EndGlobalSection
 EndGlobal

--- a/Defra.TradeImportsDataApi.sln.DotSettings
+++ b/Defra.TradeImportsDataApi.sln.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ched/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gmrs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=gvms/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ipaffs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,12 @@ RUN dotnet tool restore
 
 COPY src/Api/Api.csproj src/Api/Api.csproj
 COPY src/Domain/Domain.csproj src/Domain/Domain.csproj
+COPY src/Domain.MongoDB/Domain.MongoDB.csproj src/Domain.MongoDB/Domain.MongoDB.csproj
 COPY src/Data/Data.csproj src/Data/Data.csproj
 COPY tests/Testing/Testing.csproj tests/Testing/Testing.csproj
 COPY tests/Api.Tests/Api.Tests.csproj tests/Api.Tests/Api.Tests.csproj
 COPY tests/Api.IntegrationTests/Api.IntegrationTests.csproj tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+COPY tests/Domain.MongoDB.Tests/Domain.MongoDB.Tests.csproj tests/Domain.MongoDB.Tests/Domain.MongoDB.Tests.csproj
 COPY Defra.TradeImportsDataApi.sln Defra.TradeImportsDataApi.sln
 COPY Directory.Build.props Directory.Build.props
 
@@ -41,10 +43,12 @@ RUN dotnet restore
 
 COPY src/Api src/Api
 COPY src/Domain src/Domain
+COPY src/Domain.MongoDB src/Domain.MongoDB
 COPY src/Data src/Data
 COPY tests/Testing tests/Testing
 COPY tests/Api.Tests tests/Api.Tests
 COPY tests/Api.IntegrationTests tests/Api.IntegrationTests
+COPY tests/Domain.MongoDB.Tests tests/Domain.MongoDB.Tests
 
 RUN dotnet csharpier --check .
 
@@ -54,6 +58,7 @@ RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore tests/Api.Tests
 RUN dotnet test --no-restore tests/Api.IntegrationTests
+RUN dotnet test --no-restore tests/Domain.MongoDB.Tests
 
 FROM build AS publish
 

--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Domain\Domain.csproj" />
+    <ProjectReference Include="..\Domain.MongoDB\Domain.MongoDB.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Defra.TradeImportsDataApi.Data.Mongo;
+using Defra.TradeImportsDataApi.Domain.MongoDB;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -39,6 +40,7 @@ public static class ServiceCollectionExtensions
             };
 
             ConventionRegistry.Register(nameof(conventionPack), conventionPack, _ => true);
+            ClassMapConfiguration.Register();
 
             return client.GetDatabase(options?.Value.DatabaseName);
         });

--- a/src/Domain.MongoDB/ClassMapConfiguration.cs
+++ b/src/Domain.MongoDB/ClassMapConfiguration.cs
@@ -9,13 +9,12 @@ public static class ClassMapConfiguration
 {
     public static void Register()
     {
-        BsonClassMap.RegisterClassMap<PlannedCrossing>(cm =>
-        {
-            cm.AutoMap();
-            cm.GetMemberMap(c => c.DepartsAt)
-                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
-        });
+        RegisterGvms();
+        RegisterIpaffs();
+    }
 
+    private static void RegisterIpaffs()
+    {
         BsonClassMap.RegisterClassMap<Applicant>(cm =>
         {
             cm.AutoMap();
@@ -55,6 +54,23 @@ public static class ClassMapConfiguration
                 .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
         });
 
+        BsonClassMap.RegisterClassMap<SealCheck>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.CheckedOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+    }
+
+    private static void RegisterGvms()
+    {
+        BsonClassMap.RegisterClassMap<PlannedCrossing>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.DepartsAt)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
         BsonClassMap.RegisterClassMap<ActualCrossing>(cm =>
         {
             cm.AutoMap();
@@ -66,13 +82,6 @@ public static class ClassMapConfiguration
         {
             cm.AutoMap();
             cm.GetMemberMap(c => c.ArrivesAt)
-                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
-        });
-
-        BsonClassMap.RegisterClassMap<SealCheck>(cm =>
-        {
-            cm.AutoMap();
-            cm.GetMemberMap(c => c.CheckedOn)
                 .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
         });
     }

--- a/src/Domain.MongoDB/ClassMapConfiguration.cs
+++ b/src/Domain.MongoDB/ClassMapConfiguration.cs
@@ -1,0 +1,79 @@
+using Defra.TradeImportsDataApi.Domain.Gvms;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Defra.TradeImportsDataApi.Domain.MongoDB;
+
+public static class ClassMapConfiguration
+{
+    public static void Register()
+    {
+        BsonClassMap.RegisterClassMap<PlannedCrossing>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.DepartsAt)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<Applicant>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.SampledOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<JourneyRiskCategorisationResult>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.RiskLevelSetFor)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<LaboratoryTests>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.TestedOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<PartOne>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.ExitedPortOfOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+            cm.GetMemberMap(c => c.ArrivesAt)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+            cm.GetMemberMap(c => c.DepartedOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<RiskAssessmentResult>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.AssessedOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<ActualCrossing>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.ArrivesAt)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<CheckedInCrossing>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.ArrivesAt)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+
+        BsonClassMap.RegisterClassMap<SealCheck>(cm =>
+        {
+            cm.AutoMap();
+            cm.GetMemberMap(c => c.CheckedOn)
+                .SetSerializer(new NullableSerializer<DateTime>(new DateTimeSerializer(DateTimeKind.Unspecified)));
+        });
+    }
+}

--- a/src/Domain.MongoDB/Domain.MongoDB.csproj
+++ b/src/Domain.MongoDB/Domain.MongoDB.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>Defra.TradeImportsDataApi.Domain.MongoDB</AssemblyName>
+    <RootNamespace>Defra.TradeImportsDataApi.Domain.MongoDB</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Domain\Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -8,8 +8,4 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/Domain/Gvms/ActualCrossing.cs
+++ b/src/Domain/Gvms/ActualCrossing.cs
@@ -21,9 +21,6 @@ public class ActualCrossing
     [System.ComponentModel.Description(
         "The planned date and time of arrival, in local time of the arrival port. Must not include seconds, time zone or UTC marker"
     )]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt))]
     public DateTime? ArrivesAt { get; set; }
 }

--- a/src/Domain/Gvms/CheckedInCrossing.cs
+++ b/src/Domain/Gvms/CheckedInCrossing.cs
@@ -21,9 +21,6 @@ public class CheckedInCrossing
     [System.ComponentModel.Description(
         "The planned date and time of arrival, in local time of the arrival port. Must not include seconds, time zone or UTC marker"
     )]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt))]
     public DateTime? ArrivesAt { get; set; }
 }

--- a/src/Domain/Gvms/PlannedCrossing.cs
+++ b/src/Domain/Gvms/PlannedCrossing.cs
@@ -21,9 +21,6 @@ public class PlannedCrossing
     [System.ComponentModel.Description(
         "The planned date and time of departure, in local time of the departure port. Must not include seconds, time zone or UTC marker"
     )]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(DepartsAt)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(DepartsAt))]
     public DateTime? DepartsAt { get; set; }
 }

--- a/src/Domain/Ipaffs/Applicant.cs
+++ b/src/Domain/Ipaffs/Applicant.cs
@@ -102,9 +102,6 @@ public class Applicant
 
     [JsonPropertyName("sampledOn")]
     [System.ComponentModel.Description("DateTime")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(SampledOn)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(SampledOn))]
     public DateTime? SampledOn { get; set; }
 }

--- a/src/Domain/Ipaffs/JourneyRiskCategorisationResult.cs
+++ b/src/Domain/Ipaffs/JourneyRiskCategorisationResult.cs
@@ -32,9 +32,6 @@ public class JourneyRiskCategorisationResult
 
     [JsonPropertyName("riskLevelSetFor")]
     [System.ComponentModel.Description("The date and time the risk level has been set for a notification")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(RiskLevelSetFor)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(RiskLevelSetFor))]
     public DateTime? RiskLevelSetFor { get; set; }
 }

--- a/src/Domain/Ipaffs/LaboratoryTests.cs
+++ b/src/Domain/Ipaffs/LaboratoryTests.cs
@@ -14,10 +14,7 @@ public class LaboratoryTests
 
     [JsonPropertyName("testedOn")]
     [System.ComponentModel.Description("Date of tests")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(TestedOn)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(TestedOn))]
     public DateTime? TestedOn { get; set; }
 
     /// <summary>

--- a/src/Domain/Ipaffs/PartOne.cs
+++ b/src/Domain/Ipaffs/PartOne.cs
@@ -321,10 +321,7 @@ public class PartOne
 
     [JsonPropertyName("exitedPortOfOn")]
     [System.ComponentModel.Description("Date of Port Exit for EU Import Notification.")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(ExitedPortOfOn)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(ExitedPortOfOn))]
     public DateTime? ExitedPortOfOn { get; set; }
 
     /// <summary>
@@ -387,10 +384,7 @@ public class PartOne
 
     [JsonPropertyName("arrivesAt")]
     [System.ComponentModel.Description("DateTime")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(ArrivesAt))]
     public DateTime? ArrivesAt { get; set; }
 
     /// <summary>
@@ -399,9 +393,6 @@ public class PartOne
 
     [JsonPropertyName("departedOn")]
     [System.ComponentModel.Description("DateTime")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(DepartedOn)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(DepartedOn))]
     public DateTime? DepartedOn { get; set; }
 }

--- a/src/Domain/Ipaffs/RiskAssessmentResult.cs
+++ b/src/Domain/Ipaffs/RiskAssessmentResult.cs
@@ -22,9 +22,6 @@ public class RiskAssessmentResult
 
     [JsonPropertyName("assessedOn")]
     [System.ComponentModel.Description("Date and time of assessment")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(AssessedOn)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(AssessedOn))]
     public DateTime? AssessedOn { get; set; }
 }

--- a/src/Domain/Ipaffs/SealCheck.cs
+++ b/src/Domain/Ipaffs/SealCheck.cs
@@ -38,9 +38,6 @@ public class SealCheck
 
     [JsonPropertyName("checkedOn")]
     [System.ComponentModel.Description("date and time of seal check")]
-    [
-        UnknownTimeZoneDateTimeJsonConverter(nameof(CheckedOn)),
-        MongoDB.Bson.Serialization.Attributes.BsonDateTimeOptions(Kind = DateTimeKind.Unspecified)
-    ]
+    [UnknownTimeZoneDateTimeJsonConverter(nameof(CheckedOn))]
     public DateTime? CheckedOn { get; set; }
 }

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -9,11 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -22,10 +19,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -10,12 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
@@ -32,5 +26,5 @@
     <ProjectReference Include="..\..\src\Api\Api.csproj"/>
     <ProjectReference Include="..\Testing\Testing.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
+++ b/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
@@ -15,8 +15,12 @@ public class BsonDateTimeSerializationTests
 
         var dateTime = new DateTime(2025, 4, 6, 18, 0, 0, DateTimeKind.Unspecified);
 
+        // Gvms
         ActAndAssertRoundTrip(new PlannedCrossing { DepartsAt = dateTime }, x => x.DepartsAt);
         ActAndAssertRoundTrip(new ActualCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        ActAndAssertRoundTrip(new CheckedInCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+
+        // Ipaffs
         ActAndAssertRoundTrip(new Applicant { SampledOn = dateTime }, x => x.SampledOn);
         ActAndAssertRoundTrip(
             new JourneyRiskCategorisationResult { RiskLevelSetFor = dateTime },
@@ -27,8 +31,6 @@ public class BsonDateTimeSerializationTests
         ActAndAssertRoundTrip(new PartOne { ArrivesAt = dateTime }, x => x.ArrivesAt);
         ActAndAssertRoundTrip(new PartOne { DepartedOn = dateTime }, x => x.DepartedOn);
         ActAndAssertRoundTrip(new RiskAssessmentResult { AssessedOn = dateTime }, x => x.AssessedOn);
-        ActAndAssertRoundTrip(new ActualCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
-        ActAndAssertRoundTrip(new CheckedInCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
         ActAndAssertRoundTrip(new SealCheck { CheckedOn = dateTime }, x => x.CheckedOn);
     }
 

--- a/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
+++ b/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
@@ -11,6 +11,8 @@ public class BsonDateTimeSerializationTests
     [Fact]
     public void DomainTypesWithUnspecifiedDateTimeKind_RoundTripAsExpected()
     {
+        ClassMapConfiguration.Register();
+
         var dateTime = new DateTime(2025, 4, 6, 18, 0, 0, DateTimeKind.Unspecified);
 
         ActAndAssertRoundTrip(new PlannedCrossing { DepartsAt = dateTime }, x => x.DepartsAt);

--- a/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
+++ b/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
@@ -8,6 +8,10 @@ namespace Defra.TradeImportsDataApi.Domain.MongoDB.Tests;
 
 public class BsonDateTimeSerializationTests
 {
+    /// <summary>
+    /// Given an Unspecified DateTime Kind, serialize to BSON and then round trip back to the original type,
+    /// ensuring the Unspecified DateTime Kind is not lost.
+    /// </summary>
     [Fact]
     public void DomainTypesWithUnspecifiedDateTimeKind_RoundTripAsExpected()
     {
@@ -16,25 +20,25 @@ public class BsonDateTimeSerializationTests
         var dateTime = new DateTime(2025, 4, 6, 18, 0, 0, DateTimeKind.Unspecified);
 
         // Gvms
-        ActAndAssertRoundTrip(new PlannedCrossing { DepartsAt = dateTime }, x => x.DepartsAt);
-        ActAndAssertRoundTrip(new ActualCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
-        ActAndAssertRoundTrip(new CheckedInCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        SerializeThenDeserializeAndAssertKind(new PlannedCrossing { DepartsAt = dateTime }, x => x.DepartsAt);
+        SerializeThenDeserializeAndAssertKind(new ActualCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        SerializeThenDeserializeAndAssertKind(new CheckedInCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
 
         // Ipaffs
-        ActAndAssertRoundTrip(new Applicant { SampledOn = dateTime }, x => x.SampledOn);
-        ActAndAssertRoundTrip(
+        SerializeThenDeserializeAndAssertKind(new Applicant { SampledOn = dateTime }, x => x.SampledOn);
+        SerializeThenDeserializeAndAssertKind(
             new JourneyRiskCategorisationResult { RiskLevelSetFor = dateTime },
             x => x.RiskLevelSetFor
         );
-        ActAndAssertRoundTrip(new LaboratoryTests { TestedOn = dateTime }, x => x.TestedOn);
-        ActAndAssertRoundTrip(new PartOne { ExitedPortOfOn = dateTime }, x => x.ExitedPortOfOn);
-        ActAndAssertRoundTrip(new PartOne { ArrivesAt = dateTime }, x => x.ArrivesAt);
-        ActAndAssertRoundTrip(new PartOne { DepartedOn = dateTime }, x => x.DepartedOn);
-        ActAndAssertRoundTrip(new RiskAssessmentResult { AssessedOn = dateTime }, x => x.AssessedOn);
-        ActAndAssertRoundTrip(new SealCheck { CheckedOn = dateTime }, x => x.CheckedOn);
+        SerializeThenDeserializeAndAssertKind(new LaboratoryTests { TestedOn = dateTime }, x => x.TestedOn);
+        SerializeThenDeserializeAndAssertKind(new PartOne { ExitedPortOfOn = dateTime }, x => x.ExitedPortOfOn);
+        SerializeThenDeserializeAndAssertKind(new PartOne { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        SerializeThenDeserializeAndAssertKind(new PartOne { DepartedOn = dateTime }, x => x.DepartedOn);
+        SerializeThenDeserializeAndAssertKind(new RiskAssessmentResult { AssessedOn = dateTime }, x => x.AssessedOn);
+        SerializeThenDeserializeAndAssertKind(new SealCheck { CheckedOn = dateTime }, x => x.CheckedOn);
     }
 
-    private static void ActAndAssertRoundTrip<T>(T subject, Func<T, DateTime?> resolveDateTime)
+    private static void SerializeThenDeserializeAndAssertKind<T>(T subject, Func<T, DateTime?> resolveDateTime)
     {
         var bsonDocument = subject.ToBsonDocument();
 

--- a/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
+++ b/tests/Domain.MongoDB.Tests/BsonDateTimeSerializationTests.cs
@@ -1,0 +1,48 @@
+using Defra.TradeImportsDataApi.Domain.Gvms;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+
+namespace Defra.TradeImportsDataApi.Domain.MongoDB.Tests;
+
+public class BsonDateTimeSerializationTests
+{
+    [Fact]
+    public void DomainTypesWithUnspecifiedDateTimeKind_RoundTripAsExpected()
+    {
+        var dateTime = new DateTime(2025, 4, 6, 18, 0, 0, DateTimeKind.Unspecified);
+
+        ActAndAssertRoundTrip(new PlannedCrossing { DepartsAt = dateTime }, x => x.DepartsAt);
+        ActAndAssertRoundTrip(new ActualCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        ActAndAssertRoundTrip(new Applicant { SampledOn = dateTime }, x => x.SampledOn);
+        ActAndAssertRoundTrip(
+            new JourneyRiskCategorisationResult { RiskLevelSetFor = dateTime },
+            x => x.RiskLevelSetFor
+        );
+        ActAndAssertRoundTrip(new LaboratoryTests { TestedOn = dateTime }, x => x.TestedOn);
+        ActAndAssertRoundTrip(new PartOne { ExitedPortOfOn = dateTime }, x => x.ExitedPortOfOn);
+        ActAndAssertRoundTrip(new PartOne { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        ActAndAssertRoundTrip(new PartOne { DepartedOn = dateTime }, x => x.DepartedOn);
+        ActAndAssertRoundTrip(new RiskAssessmentResult { AssessedOn = dateTime }, x => x.AssessedOn);
+        ActAndAssertRoundTrip(new ActualCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        ActAndAssertRoundTrip(new CheckedInCrossing { ArrivesAt = dateTime }, x => x.ArrivesAt);
+        ActAndAssertRoundTrip(new SealCheck { CheckedOn = dateTime }, x => x.CheckedOn);
+    }
+
+    private static void ActAndAssertRoundTrip<T>(T subject, Func<T, DateTime?> resolveDateTime)
+    {
+        var bsonDocument = subject.ToBsonDocument();
+
+        bsonDocument.Should().NotBeNull();
+
+        var subject2 = BsonSerializer.Deserialize<T>(bsonDocument);
+
+        subject2.Should().NotBeNull();
+
+        var dateTimeValue = resolveDateTime(subject2);
+        dateTimeValue.Should().NotBeNull();
+        dateTimeValue.Should().Be(resolveDateTime(subject), "(type tested was {0})", typeof(T).Name);
+        dateTimeValue.Value.Kind.Should().Be(DateTimeKind.Unspecified);
+    }
+}

--- a/tests/Domain.MongoDB.Tests/Domain.MongoDB.Tests.csproj
+++ b/tests/Domain.MongoDB.Tests/Domain.MongoDB.Tests.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Domain\Domain.csproj"/>
+    <ProjectReference Include="..\..\src\Domain.MongoDB\Domain.MongoDB.csproj"/>
     <ProjectReference Include="..\Testing\Testing.csproj" />
   </ItemGroup>
 

--- a/tests/Domain.MongoDB.Tests/Domain.MongoDB.Tests.csproj
+++ b/tests/Domain.MongoDB.Tests/Domain.MongoDB.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Defra.TradeImportsDataApi.Domain.MongoDB.Tests</AssemblyName>
+    <RootNamespace>Defra.TradeImportsDataApi.Domain.MongoDB.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Domain\Domain.csproj"/>
+    <ProjectReference Include="..\Testing\Testing.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
As per PR title.

This is needed so we can use the Domain project independently in things like an API client (as it will need to be published to nuget).

A small tidy of test project references is also included.