### PR TITLE
Additional nuget related changes

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Check with Trivy
         run: docker run -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image trade-imports-data-api:latest --ignore-unfixed
       - name: Pack NuGets
+        if: github.actor != 'dependabot[bot]'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
           BUILD_NUMBER: ${{ github.run_number }}
@@ -46,6 +47,7 @@ jobs:
           dotnet pack --no-restore --configuration Release -o ./nupkg \
             /p:VersionSuffix="pr-$PR_NUMBER.$BUILD_NUMBER"
       - name: Publish NuGets
+        if: github.actor != 'dependabot[bot]'
         run: |
           dotnet nuget push ./nupkg/*.nupkg \
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -11,6 +11,9 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  packages: write
+
 jobs:
   pr-validator:
     name: Run Pull Request Checks


### PR DESCRIPTION
Add package write permission for a PR workflow - not sure why this was working before but a dependabot related PR started complaining when it wasn't there.

Also prevent nuget operations for PR builds if it's a dependabot origin change - we can review this going forward as there will come a time when a dependency being updated will warrant a bump of one or more nuget packages we produce.