### PR TITLE
Publish open API spec as build artifact

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -50,6 +50,13 @@ jobs:
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
+      - name: Generate OpenAPI specification
+        run: make generate-openapi-spec
+      - name: Save OpenApi specification
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi.json
+          path: openapi.json
   sonarcloud-scan:
     name: CDP SonarCloud Scan
     uses: ./.github/workflows/sonarcloud.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,13 @@ jobs:
             --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
             --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
+      - name: Generate OpenAPI specification
+        run: make generate-openapi-spec
+      - name: Save OpenApi specification
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi.json
+          path: openapi.json
   sonarcloud-scan:
     name: CDP SonarCloud Scan
     uses: ./.github/workflows/sonarcloud.yml

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ dependencies:
 	dotnet tool restore
 
 generate-openapi-spec: dependencies
-	dotnet build src/Api/Api.csproj --no-restore -c Release
-	dotnet swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.TradeImportsData.Api.dll v1
+	dotnet build src/Api/Api.csproj -c Release
+	dotnet swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.TradeImportsDataApi.Api.dll v1
 
 lint-openapi-spec: generate-openapi-spec
 	docker run --rm -v "$(PWD):/work:ro" dshanley/vacuum lint -d -r .vacuum.yml openapi.json


### PR DESCRIPTION
On a PR build and a main build publish the open API spec as a point in time reference. Other teams, such as PHA API owners, can then use the spec as they need.