### PR TITLE
Revert "Use async console logger for improved performance"

### DIFF
--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -15,16 +15,9 @@
     },
     "WriteTo": [
       {
-        "Name": "Async",
+        "Name": "Console",
         "Args": {
-          "configure": [
-            {
-              "Name": "Console",
-              "Args": {
-                "formatter": "Elastic.CommonSchema.Serilog.EcsTextFormatter, Elastic.CommonSchema.Serilog"
-              }
-            }
-          ]
+          "formatter": "Elastic.CommonSchema.Serilog.EcsTextFormatter, Elastic.CommonSchema.Serilog"
         }
       }
     ]


### PR DESCRIPTION
Reverts DEFRA/trade-imports-data-api#28

Logging stopped when deployed to CDP.