### PR TITLE
Add missing Serilog async package

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="8.1.0" />
   </ItemGroup>


### PR DESCRIPTION
As per PR title.

Logging is not working in CDP with the async writer. This should hopefully sort it.