### PR TITLE
Specify the topic name to be published to directly rather than trying to use discovery on topic name alone

### DIFF
--- a/src/Api/Configuration/ResourceEventOptions.cs
+++ b/src/Api/Configuration/ResourceEventOptions.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Defra.TradeImportsDataApi.Api.Configuration;
+
+public class ResourceEventOptions
+{
+    [Required]
+    public required string ArnPrefix { get; init; }
+
+    [Required]
+    public required string TopicName { get; init; }
+
+    public string TopicArn => $"{ArnPrefix}:{TopicName}";
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Amazon.SimpleNotificationService;
 using Defra.TradeImportsDataApi.Api.Authentication;
+using Defra.TradeImportsDataApi.Api.Configuration;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.Gmrs;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
@@ -127,6 +128,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddTransient<IGmrService, GmrService>();
     builder.Services.AddTransient<IImportPreNotificationService, ImportPreNotificationService>();
     builder.Services.AddTransient<ICustomsDeclarationService, CustomsDeclarationService>();
+    builder.Services.AddOptions<ResourceEventOptions>().BindConfiguration("ResourceEvents").ValidateOptions();
     builder.Services.AddSingleton<IResourceEventPublisher, ResourceEventPublisher>();
     builder.Services.AddDefaultAWSOptions(builder.Configuration.GetAWSOptions());
     builder.Services.AddAWSService<IAmazonSimpleNotificationService>();

--- a/src/Api/appsettings.cdp.dev.json
+++ b/src/Api/appsettings.cdp.dev.json
@@ -1,2 +1,5 @@
 {
+  "ResourceEvents": {
+    "ArnPrefix": "arn:aws:sns:eu-west-2:332499610595"
+  }
 }

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -64,5 +64,9 @@
         ]
       }
     }
+  },
+  "ResourceEvents": {
+    "ArnPrefix": "arn:aws:sns:eu-west-2:000000000000",
+    "TopicName": "trade_imports_data_upserted"
   }
 }


### PR DESCRIPTION
As per PR title.

We don't appear to have adequate permissions within CDP to list topics and then find the ARN.