### PR TITLE
Prevent existing Created date on entity from being lost on update

### DIFF
--- a/src/Api/Endpoints/Gmrs/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/Gmrs/EndpointRouteBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDataApi.Api.Authentication;
+using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Api.Extensions;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Api.Utils;
@@ -103,6 +104,10 @@ public static class EndpointRouteBuilderExtensions
         catch (ConcurrencyException)
         {
             return Results.Conflict();
+        }
+        catch (EntityNotFoundException)
+        {
+            return Results.NotFound();
         }
     }
 }

--- a/src/Api/Services/CustomsDeclarationService.cs
+++ b/src/Api/Services/CustomsDeclarationService.cs
@@ -54,6 +54,8 @@ public class CustomsDeclarationService(IDbContext dbContext, IResourceEventPubli
             throw new EntityNotFoundException(nameof(CustomsDeclarationEntity), customsDeclarationEntity.Id);
         }
 
+        customsDeclarationEntity.Created = existing.Created;
+
         await dbContext.CustomsDeclarations.Update(customsDeclarationEntity, etag, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         await resourceEventPublisher.Publish(

--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -1,3 +1,4 @@
+using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 
@@ -20,6 +21,14 @@ public class GmrService(IDbContext dbContext) : IGmrService
 
     public async Task<GmrEntity> Update(GmrEntity gmrEntity, string etag, CancellationToken cancellationToken)
     {
+        var existing = await dbContext.Gmrs.Find(gmrEntity.Id, cancellationToken);
+        if (existing == null)
+        {
+            throw new EntityNotFoundException(nameof(GmrEntity), gmrEntity.Id);
+        }
+
+        gmrEntity.Created = existing.Created;
+
         await dbContext.Gmrs.Update(gmrEntity, etag, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -59,6 +59,8 @@ public class ImportPreNotificationService(IDbContext dbContext, IResourceEventPu
             throw new EntityNotFoundException(nameof(ImportPreNotificationEntity), importPreNotificationEntity.Id);
         }
 
+        importPreNotificationEntity.Created = existing.Created;
+
         await dbContext.ImportPreNotifications.Update(importPreNotificationEntity, etag, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         await resourceEventPublisher.Publish(

--- a/tests/Api.IntegrationTests/Endpoints/CustomsDeclarationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/CustomsDeclarationTests.cs
@@ -44,6 +44,8 @@ public class CustomsDeclarationTests : SqsTestBase
 
         result = await client.GetCustomsDeclaration(mrn, CancellationToken.None);
         result.Should().NotBeNull();
+        result.Created.Should().BeAfter(DateTime.MinValue);
+        result.Updated.Should().BeAfter(DateTime.MinValue);
         result.ClearanceRequest?.ExternalVersion.Should().Be(1);
 
         await client.PutCustomsDeclaration(
@@ -53,9 +55,11 @@ public class CustomsDeclarationTests : SqsTestBase
             CancellationToken.None
         );
 
-        result = await client.GetCustomsDeclaration(mrn, CancellationToken.None);
-        result.Should().NotBeNull();
-        result.ClearanceRequest?.ExternalVersion.Should().Be(2);
+        var result2 = await client.GetCustomsDeclaration(mrn, CancellationToken.None);
+        result2.Should().NotBeNull();
+        result2.ClearanceRequest?.ExternalVersion.Should().Be(2);
+        result2.Created.Should().Be(result.Created);
+        result2.Updated.Should().BeAfter(result.Updated);
     }
 
     [Fact]

--- a/tests/Api.IntegrationTests/Endpoints/GmrTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/GmrTests.cs
@@ -34,6 +34,8 @@ public class GmrTests : IntegrationTestBase
         result = await client.GetGmr(gmrId, CancellationToken.None);
         result.Should().NotBeNull();
         result.Gmr.State.Should().Be(State.Open);
+        result.Created.Should().BeAfter(DateTime.MinValue);
+        result.Updated.Should().BeAfter(DateTime.MinValue);
 
         await client.PutGmr(
             gmrId,
@@ -42,9 +44,11 @@ public class GmrTests : IntegrationTestBase
             CancellationToken.None
         );
 
-        result = await client.GetGmr(gmrId, CancellationToken.None);
-        result.Should().NotBeNull();
-        result.Gmr.State.Should().Be(State.Finalised);
+        var result2 = await client.GetGmr(gmrId, CancellationToken.None);
+        result2.Should().NotBeNull();
+        result2.Gmr.State.Should().Be(State.Finalised);
+        result2.Created.Should().Be(result.Created);
+        result2.Updated.Should().BeAfter(result.Updated);
     }
 
     [Fact]

--- a/tests/Api.IntegrationTests/Endpoints/ImportPreNotificationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportPreNotificationTests.cs
@@ -66,6 +66,8 @@ public class ImportPreNotificationTests : SqsTestBase
         result = await client.GetImportPreNotification(chedRef, CancellationToken.None);
         result.Should().NotBeNull();
         result.ImportPreNotification.Version.Should().Be(1);
+        result.Created.Should().BeAfter(DateTime.MinValue);
+        result.Updated.Should().BeAfter(DateTime.MinValue);
 
         await client.PutImportPreNotification(
             chedRef,
@@ -74,9 +76,11 @@ public class ImportPreNotificationTests : SqsTestBase
             CancellationToken.None
         );
 
-        result = await client.GetImportPreNotification(chedRef, CancellationToken.None);
-        result.Should().NotBeNull();
-        result.ImportPreNotification.Version.Should().Be(2);
+        var result2 = await client.GetImportPreNotification(chedRef, CancellationToken.None);
+        result2.Should().NotBeNull();
+        result2.ImportPreNotification.Version.Should().Be(2);
+        result2.Created.Should().Be(result.Created);
+        result2.Updated.Should().BeAfter(result.Updated);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/GmrServiceTests.cs
+++ b/tests/Api.Tests/Services/GmrServiceTests.cs
@@ -1,0 +1,64 @@
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Api.Services;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Domain.Gvms;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Services;
+
+public class GmrServiceTests
+{
+    [Fact]
+    public async Task Insert_ShouldInsertAndPublish()
+    {
+        var mockDbContext = Substitute.For<IDbContext>();
+        var subject = new GmrService(mockDbContext);
+        var entity = new GmrEntity { Id = "id", Gmr = new Gmr() };
+
+        await subject.Insert(entity, CancellationToken.None);
+
+        await mockDbContext.Gmrs.Received().Insert(entity, CancellationToken.None);
+        await mockDbContext.Received().SaveChangesAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task Update_WhenNotExists_ShouldThrow()
+    {
+        var mockDbContext = Substitute.For<IDbContext>();
+        var subject = new GmrService(mockDbContext);
+        var entity = new GmrEntity { Id = "id", Gmr = new Gmr() };
+
+        var act = async () => await subject.Update(entity, "etag", CancellationToken.None);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+
+    [Fact]
+    public async Task Update_ShouldUpdateAndPublish()
+    {
+        var mockDbContext = Substitute.For<IDbContext>();
+        const string id = "id";
+        mockDbContext
+            .Gmrs.Find(id)
+            .Returns(
+                new GmrEntity
+                {
+                    Id = id,
+                    Gmr = new Gmr { State = State.Open },
+                }
+            );
+        var subject = new GmrService(mockDbContext);
+        var entity = new GmrEntity
+        {
+            Id = id,
+            Gmr = new Gmr { State = State.Completed },
+        };
+
+        await subject.Update(entity, "etag", CancellationToken.None);
+
+        await mockDbContext.Gmrs.Received().Update(entity, "etag", CancellationToken.None);
+        await mockDbContext.Received().SaveChangesAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
During an end to end test, it was observed that `Created` entity date was `DateTime.MinValue` after an update. 

This behaviour has now been fixed and the `Created` value from the existing entity is preserved when saving an update.