### PR TITLE
Update to latest versions

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.134" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.137" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.4" />

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.134" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.137" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/tests/Testing/Testing.csproj
+++ b/tests/Testing/Testing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -25,7 +25,7 @@
     <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.7.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="29.2.0" />
+    <PackageReference Include="Verify.Xunit" Version="29.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As per PR title.

Dependabot is currently struggling with AWS 4 part versions and based on our config it's producing a single PR per nuget. Need to change this but for now, it's being done manually.