### PR TITLE
Include new `childResourceType` message attribute if one is set in the resource event

### DIFF
--- a/src/Api.Client/Api.Client.csproj
+++ b/src/Api.Client/Api.Client.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Api.Client</PackageId>
-    <VersionPrefix>0.8.0</VersionPrefix>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Client</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Api/Services/ResourceEventExtensions.cs
+++ b/src/Api/Services/ResourceEventExtensions.cs
@@ -49,7 +49,17 @@ public static class ResourceEventExtensions
         where TDataEntity : IDataEntity
         where TDomain : class
     {
-        return @event with { ChangeSet = CreateChangeSet(current, previous) };
+        var changeSet = CreateChangeSet(current, previous);
+        var childResourceTypes = changeSet.Select(x => x.Path[1..]).Distinct().ToArray();
+
+        if (childResourceTypes.Length > 1)
+            throw new InvalidOperationException("Change set contains multiple child resource types");
+
+        return @event with
+        {
+            ChangeSet = changeSet,
+            ChildResourceType = childResourceTypes.FirstOrDefault(),
+        };
     }
 
     private static List<Diff> CreateChangeSet<T>([DisallowNull] T current, [DisallowNull] T previous)

--- a/src/Api/Services/ResourceEventPublisher.cs
+++ b/src/Api/Services/ResourceEventPublisher.cs
@@ -26,6 +26,14 @@ public class ResourceEventPublisher(
             },
         };
 
+        if (@event.ChildResourceType is not null)
+        {
+            messageAttributes.Add(
+                "childResourceType",
+                new MessageAttributeValue { StringValue = @event.ChildResourceType, DataType = "String" }
+            );
+        }
+
         AddTraceIdIfPresent(messageAttributes);
 
         var request = new PublishRequest

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Domain</PackageId>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Domain</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Events/ResourceEvent.cs
+++ b/src/Domain/Events/ResourceEvent.cs
@@ -10,6 +10,9 @@ public record ResourceEvent<T>
     [JsonPropertyName("resourceType")]
     public required string ResourceType { get; init; }
 
+    [JsonPropertyName("childResourceType")]
+    public string? ChildResourceType { get; init; }
+
     [JsonPropertyName("operation")]
     public required string Operation { get; init; }
 

--- a/src/Domain/Events/ResourceEventChildResourceTypes.cs
+++ b/src/Domain/Events/ResourceEventChildResourceTypes.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 namespace Defra.TradeImportsDataApi.Domain.Events;
 
 [ExcludeFromCodeCoverage]
-// ReSharper disable once UnusedType.Global
 public static class ResourceEventChildResourceTypes
 {
     public const string ClearanceRequest = nameof(ClearanceRequest);

--- a/src/Domain/Events/ResourceEventChildResourceTypes.cs
+++ b/src/Domain/Events/ResourceEventChildResourceTypes.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Defra.TradeImportsDataApi.Domain.Events;
+
+[ExcludeFromCodeCoverage]
+// ReSharper disable once UnusedType.Global
+public static class ResourceEventChildResourceTypes
+{
+    public const string ClearanceRequest = nameof(ClearanceRequest);
+
+    public const string ClearanceDecision = nameof(ClearanceDecision);
+
+    public const string Finalisation = nameof(Finalisation);
+}

--- a/tests/Api.Tests/Services/ResourceEventExtensionsTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventExtensionsTests.cs
@@ -21,7 +21,7 @@ public class ResourceEventExtensionsTests
     }
 
     [Fact]
-    public void WhenWithChangeSet_ShouldCreateChangeSet()
+    public void WhenWithChangeSet_AndMultipleChildFieldsChanging_ShouldThrow()
     {
         var previous = new FixtureEntity
         {
@@ -39,15 +39,60 @@ public class ResourceEventExtensionsTests
         };
         var subject = current.ToResourceEvent("operation");
 
+        var act = () => subject.WithChangeSet(current, previous);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void WhenWithChangeSet_ShouldCreateChangeSet()
+    {
+        var previous = new FixtureEntity
+        {
+            Name = "From",
+            Id = "id",
+            ETag = "etag",
+            FixtureType = FixtureType.Value1,
+        };
+        var current = new FixtureEntity
+        {
+            Name = "To",
+            Id = "id",
+            ETag = "etag",
+            FixtureType = FixtureType.Value1,
+        };
+        var subject = current.ToResourceEvent("operation");
+
         var result = subject.WithChangeSet(current, previous);
 
-        result.ChangeSet.Count.Should().Be(2);
+        result.ChangeSet.Count.Should().Be(1);
         result.ChangeSet[0].Operation.Should().Be("Replace");
         result.ChangeSet[0].Path.Should().Be("/Name");
         result.ChangeSet[0].Value.Should().Be("To");
-        result.ChangeSet[1].Operation.Should().Be("Replace");
-        result.ChangeSet[1].Path.Should().Be("/FixtureType");
-        result.ChangeSet[1].Value.Should().Be("Value2");
+    }
+
+    [Fact]
+    public void WhenWithChangeSet_ShouldSetChildResourceType()
+    {
+        var previous = new FixtureEntity
+        {
+            Name = "From",
+            Id = "id",
+            ETag = "etag",
+            FixtureType = FixtureType.Value1,
+        };
+        var current = new FixtureEntity
+        {
+            Name = "To",
+            Id = "id",
+            ETag = "etag",
+            FixtureType = FixtureType.Value1,
+        };
+        var subject = current.ToResourceEvent("operation");
+
+        var result = subject.WithChangeSet(current, previous);
+
+        result.ChildResourceType.Should().Be("Name");
     }
 
     private class FixtureEntity : IDataEntity

--- a/tests/Api.Tests/Services/ResourceEventPublisherTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventPublisherTests.cs
@@ -46,7 +46,7 @@ public class ResourceEventPublisherTests
                     && x.MessageAttributes.ContainsKey("resourceType")
                     && x.MessageAttributes["resourceType"].StringValue == "resourceType"
                     && x.Message
-                        == "{\"resourceId\":\"resourceId\",\"resourceType\":\"resourceType\",\"operation\":\"operation\",\"resource\":null,\"etag\":null,\"timestamp\":\"2025-04-16T07:00:00Z\",\"changeSet\":[]}"
+                        == "{\"resourceId\":\"resourceId\",\"resourceType\":\"resourceType\",\"childResourceType\":null,\"operation\":\"operation\",\"resource\":null,\"etag\":null,\"timestamp\":\"2025-04-16T07:00:00Z\",\"changeSet\":[]}"
                 ),
                 CancellationToken.None
             );


### PR DESCRIPTION
As per PR title.

Current known child resource types are:

- ClearanceRequest
- ClearanceDecision
- Finalisation

See `ResourceEventChildResourceTypes` when consuming as that represents all known child resource types that are currently expected.

Note that message attribute key names are camel case.

Only one known child resource type value is allowed. We could include an array of known child resource types if needed however that may complicate any AWS topic to queue filters as we should only expect a single child resource property to be updated at time of writing.