### PR TITLE
Ensure sub resource type resolved when child of child properties are being updated

### DIFF
--- a/src/Api/Services/ResourceEventExtensions.cs
+++ b/src/Api/Services/ResourceEventExtensions.cs
@@ -51,7 +51,7 @@ public static class ResourceEventExtensions
     {
         var changeSet = CreateChangeSet(current, previous);
         var knownSubResourceTypes = changeSet
-            .Select(x => x.Path[1..])
+            .Select(x => x.Path.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault())
             .Distinct()
             .Select(x =>
                 x switch

--- a/tests/Api.Tests/Services/ResourceEventExtensionsTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventExtensionsTests.cs
@@ -112,6 +112,26 @@ public class ResourceEventExtensionsTests
     }
 
     [Fact]
+    public void WhenWithChangeSet_AndSubResourceTypeIsClearanceRequest_WithChildPropertyChange_ShouldSetSubResourceType()
+    {
+        var subject = new FixtureEntity { Id = "id", ETag = "etag" };
+        var previous = new CustomsDeclarationData(
+            new ClearanceRequest { ExternalVersion = 1 },
+            ClearanceDecision: null,
+            Finalisation: null
+        );
+        var current = new CustomsDeclarationData(
+            new ClearanceRequest { ExternalVersion = 2 },
+            ClearanceDecision: null,
+            Finalisation: null
+        );
+
+        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+
+        result.SubResourceType.Should().Be("ClearanceRequest");
+    }
+
+    [Fact]
     public void WhenWithChangeSet_AndSubResourceTypeIsClearanceDecision_ShouldSetSubResourceType()
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };


### PR DESCRIPTION
This PR fixes an issue introduced in PR https://github.com/DEFRA/trade-imports-data-api/pull/56.

When a child of child property was the only field reported in the change set, the sub resource type was not being set as the logic to resolve it was incorrect.

We now split on `/`, remove empty entries and then take the first.