### PR TITLE
Add new InboundError type off the CustomsDeclaration

### DIFF
--- a/src/Api.Client/Api.Client.csproj
+++ b/src/Api.Client/Api.Client.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Api.Client</PackageId>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Client</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Api.Client/CustomsDeclarationResponse.cs
+++ b/src/Api.Client/CustomsDeclarationResponse.cs
@@ -8,6 +8,7 @@ public record CustomsDeclarationResponse(
     [property: JsonPropertyName("clearanceRequest")] ClearanceRequest? ClearanceRequest,
     [property: JsonPropertyName("clearanceDecision")] ClearanceDecision? ClearanceDecision,
     [property: JsonPropertyName("finalisation")] Finalisation? Finalisation,
+    [property: JsonPropertyName("inboundError")] InboundError? InboundError,
     [property: JsonPropertyName("created")] DateTime Created,
     [property: JsonPropertyName("updated")] DateTime Updated,
     string? ETag = null

--- a/src/Api/Endpoints/CustomsDeclarations/CustomsDeclarationResponse.cs
+++ b/src/Api/Endpoints/CustomsDeclarations/CustomsDeclarationResponse.cs
@@ -8,6 +8,7 @@ public record CustomsDeclarationResponse(
     [property: JsonPropertyName("clearanceRequest")] ClearanceRequest? ClearanceRequest,
     [property: JsonPropertyName("clearanceDecision")] ClearanceDecision? ClearanceDecision,
     [property: JsonPropertyName("finalisation")] Finalisation? Finalisation,
+    [property: JsonPropertyName("inboundError")] InboundError? InboundError,
     [property: JsonPropertyName("created")] DateTime Created,
     [property: JsonPropertyName("updated")] DateTime Updated
 );

--- a/src/Api/Endpoints/CustomsDeclarations/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/CustomsDeclarations/EndpointRouteBuilderExtensions.cs
@@ -91,6 +91,7 @@ public static class EndpointRouteBuilderExtensions
                 customsDeclarationEntity.ClearanceRequest,
                 customsDeclarationEntity.ClearanceDecision,
                 customsDeclarationEntity.Finalisation,
+                customsDeclarationEntity.InboundError,
                 customsDeclarationEntity.Created,
                 customsDeclarationEntity.Updated
             )
@@ -140,6 +141,7 @@ public static class EndpointRouteBuilderExtensions
             ClearanceRequest = data.ClearanceRequest,
             ClearanceDecision = data.ClearanceDecision,
             Finalisation = data.Finalisation,
+            InboundError = data.InboundError,
         };
 
         var etag = ETags.ValidateAndParseFirst(ifMatch);

--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -125,6 +125,7 @@ public static class EndpointRouteBuilderExtensions
                     customsDeclarationEntity.ClearanceRequest,
                     customsDeclarationEntity.ClearanceDecision,
                     customsDeclarationEntity.Finalisation,
+                    customsDeclarationEntity.InboundError,
                     customsDeclarationEntity.Created,
                     customsDeclarationEntity.Updated
                 ))

--- a/src/Api/Services/ResourceEventExtensions.cs
+++ b/src/Api/Services/ResourceEventExtensions.cs
@@ -59,6 +59,7 @@ public static class ResourceEventExtensions
                     ResourceEventSubResourceTypes.ClearanceRequest => ResourceEventSubResourceTypes.ClearanceRequest,
                     ResourceEventSubResourceTypes.ClearanceDecision => ResourceEventSubResourceTypes.ClearanceDecision,
                     ResourceEventSubResourceTypes.Finalisation => ResourceEventSubResourceTypes.Finalisation,
+                    ResourceEventSubResourceTypes.InboundError => ResourceEventSubResourceTypes.InboundError,
                     _ => null,
                 }
             )

--- a/src/Api/Services/ResourceEventPublisher.cs
+++ b/src/Api/Services/ResourceEventPublisher.cs
@@ -13,7 +13,8 @@ public class ResourceEventPublisher(
     IAmazonSimpleNotificationService simpleNotificationService,
     IOptions<TraceHeader> traceHeaderOptions,
     HeaderPropagationValues headerPropagationValues,
-    IOptions<ResourceEventOptions> resourceEventOptions
+    IOptions<ResourceEventOptions> resourceEventOptions,
+    ILogger<ResourceEventPublisher> logger
 ) : IResourceEventPublisher
 {
     public async Task Publish<T>(ResourceEvent<T> @event, CancellationToken cancellationToken)
@@ -44,6 +45,13 @@ public class ResourceEventPublisher(
         };
 
         await simpleNotificationService.PublishAsync(request, cancellationToken);
+
+        logger.LogInformation(
+            "Published resource event {ResourceType} {Operation} {SubResourceType}",
+            @event.ResourceType,
+            @event.Operation,
+            @event.SubResourceType
+        );
     }
 
     private void AddTraceIdIfPresent(Dictionary<string, MessageAttributeValue> messageAttributes)

--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -17,7 +17,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "{Timestamp:o} [{Level:u4}] ({Application}/{MachineName}/{ThreadId}/{SourceContext}.{Method}) {Message}{NewLine}{Exception}"
+          "outputTemplate": "{Timestamp:o} [{Level:u4}] {Message} {Properties}{NewLine}{Exception}"
         }
       }
     ]

--- a/src/Data/Entities/CustomsDeclarationEntity.cs
+++ b/src/Data/Entities/CustomsDeclarationEntity.cs
@@ -20,6 +20,8 @@ namespace Defra.TradeImportsDataApi.Data.Entities
 
         public Finalisation? Finalisation { get; set; }
 
+        public InboundError? InboundError { get; set; }
+
         public void OnSave()
         {
             ImportPreNotificationIdentifiers.Clear();

--- a/src/Domain/CustomsDeclaration/CustomsDeclaration.cs
+++ b/src/Domain/CustomsDeclaration/CustomsDeclaration.cs
@@ -7,4 +7,6 @@ public class CustomsDeclaration
     public ClearanceDecision? ClearanceDecision { get; set; }
 
     public Finalisation? Finalisation { get; set; }
+
+    public InboundError? InboundError { get; set; }
 }

--- a/src/Domain/CustomsDeclaration/InboundError.cs
+++ b/src/Domain/CustomsDeclaration/InboundError.cs
@@ -4,12 +4,6 @@ namespace Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 
 public class InboundError
 {
-    [JsonPropertyName("externalCorrelationId")]
-    public string? ExternalCorrelationId { get; set; }
-
-    [JsonPropertyName("externalVersion")]
-    public int? ExternalVersion { get; set; }
-
-    [JsonPropertyName("errors")]
-    public InboundErrorItem[]? Errors { get; set; }
+    [JsonPropertyName("notifications")]
+    public InboundErrorNotification[]? Notifications { get; set; }
 }

--- a/src/Domain/CustomsDeclaration/InboundError.cs
+++ b/src/Domain/CustomsDeclaration/InboundError.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+
+public class InboundError
+{
+    [JsonPropertyName("externalCorrelationId")]
+    public string? ExternalCorrelationId { get; set; }
+
+    [JsonPropertyName("externalVersion")]
+    public int? ExternalVersion { get; set; }
+
+    [JsonPropertyName("errors")]
+    public InboundErrorItem[]? Errors { get; set; }
+}

--- a/src/Domain/CustomsDeclaration/InboundErrorItem.cs
+++ b/src/Domain/CustomsDeclaration/InboundErrorItem.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+
+public class InboundErrorItem
+{
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}

--- a/src/Domain/CustomsDeclaration/InboundErrorNotification.cs
+++ b/src/Domain/CustomsDeclaration/InboundErrorNotification.cs
@@ -10,9 +10,6 @@ public class InboundErrorNotification
     [JsonPropertyName("externalVersion")]
     public int? ExternalVersion { get; set; }
 
-    [JsonPropertyName("code")]
-    public string? Code { get; set; }
-
-    [JsonPropertyName("message")]
-    public string? Message { get; set; }
+    [JsonPropertyName("errors")]
+    public InboundErrorItem[]? Errors { get; set; }
 }

--- a/src/Domain/CustomsDeclaration/InboundErrorNotification.cs
+++ b/src/Domain/CustomsDeclaration/InboundErrorNotification.cs
@@ -2,8 +2,14 @@ using System.Text.Json.Serialization;
 
 namespace Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 
-public class InboundErrorItem
+public class InboundErrorNotification
 {
+    [JsonPropertyName("externalCorrelationId")]
+    public string? ExternalCorrelationId { get; set; }
+
+    [JsonPropertyName("externalVersion")]
+    public int? ExternalVersion { get; set; }
+
     [JsonPropertyName("code")]
     public string? Code { get; set; }
 

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Domain</PackageId>
-    <VersionPrefix>0.9.0</VersionPrefix>
+    <VersionPrefix>0.10.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Domain</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Events/ResourceEventSubResourceTypes.cs
+++ b/src/Domain/Events/ResourceEventSubResourceTypes.cs
@@ -10,4 +10,6 @@ public static class ResourceEventSubResourceTypes
     public const string ClearanceDecision = nameof(ClearanceDecision);
 
     public const string Finalisation = nameof(Finalisation);
+
+    public const string InboundError = nameof(InboundError);
 }

--- a/tests/Api.Client.Tests/Endpoints/CustomsDeclarations/GetTests.GetCustomsDeclaration_WhenFound_ShouldNotBeNull.verified.txt
+++ b/tests/Api.Client.Tests/Endpoints/CustomsDeclarations/GetTests.GetCustomsDeclaration_WhenFound_ShouldNotBeNull.verified.txt
@@ -19,6 +19,7 @@
   },
   ClearanceDecision: null,
   Finalisation: null,
+  InboundError: null,
   Created: 2025-04-07 11:00 Utc,
   Updated: 2025-04-07 11:15 Utc,
   ETag: "etag"

--- a/tests/Api.Client.Tests/Endpoints/CustomsDeclarations/GetTests.cs
+++ b/tests/Api.Client.Tests/Endpoints/CustomsDeclarations/GetTests.cs
@@ -52,6 +52,7 @@ public class GetTests : WireMockTestBase<WireMockContext>
                                 new ClearanceRequest(),
                                 ClearanceDecision: null,
                                 Finalisation: null,
+                                InboundError: null,
                                 created,
                                 updated
                             )

--- a/tests/Api.Client.Tests/Endpoints/ImportPreNotifications/GetCustomsDeclarationsTests.GetCustomDeclarationsByChed_WhenFound_ShouldNotBeNull.verified.txt
+++ b/tests/Api.Client.Tests/Endpoints/ImportPreNotifications/GetCustomsDeclarationsTests.GetCustomDeclarationsByChed_WhenFound_ShouldNotBeNull.verified.txt
@@ -4,6 +4,7 @@
     ClearanceRequest: null,
     ClearanceDecision: null,
     Finalisation: null,
+    InboundError: null,
     Created: 0001-01-01,
     Updated: 0001-01-01,
     ETag: etag

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenFound_ShouldReturnContent.verified.txt
@@ -19,6 +19,7 @@
   },
   clearanceDecision: null,
   finalisation: null,
+  inboundError: null,
   created: 2025-04-03T10:00:00Z,
   updated: 2025-04-03T10:15:00Z
 }

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -341,6 +341,24 @@
     "finalState": 0,
     "isManualRelease": true
   },
+  "inboundError": {
+    "externalCorrelationId": "ExternalCorrelationId6aeab374-36e3-4baf-85d0-11a1b9ed39df",
+    "externalVersion": 237,
+    "errors": [
+      {
+        "code": "Code608891fd-f4e4-482d-9466-8a0767eaa29d",
+        "message": "Message714fdb0d-68ff-4500-a663-3266bacf2730"
+      },
+      {
+        "code": "Code7028e97f-2bf9-48fb-8fc5-b595f0a923e2",
+        "message": "Messageae1a5bf5-a246-492e-8af8-99cc380ad892"
+      },
+      {
+        "code": "Codef0b58749-eb9b-483d-97b6-6715fd2d0ca1",
+        "message": "Message373f1ed1-3c0a-49ac-89ae-a07fe8f7c8d6"
+      }
+    ]
+  },
   "created": "2025-04-03T10:00:00Z",
   "updated": "2025-04-03T10:15:00Z"
 }

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -342,20 +342,24 @@
     "isManualRelease": true
   },
   "inboundError": {
-    "externalCorrelationId": "ExternalCorrelationId6aeab374-36e3-4baf-85d0-11a1b9ed39df",
-    "externalVersion": 237,
-    "errors": [
+    "notifications": [
       {
-        "code": "Code608891fd-f4e4-482d-9466-8a0767eaa29d",
-        "message": "Message714fdb0d-68ff-4500-a663-3266bacf2730"
+        "externalCorrelationId": "ExternalCorrelationId1876c2e7-36e8-4704-b2c6-b5e96e2f117b",
+        "externalVersion": 230,
+        "code": "Code2ae97016-7148-47c6-820d-6bca40482b0a",
+        "message": "Messageb56851be-4e82-48de-ad19-62ffa7833e2b"
       },
       {
-        "code": "Code7028e97f-2bf9-48fb-8fc5-b595f0a923e2",
-        "message": "Messageae1a5bf5-a246-492e-8af8-99cc380ad892"
+        "externalCorrelationId": "ExternalCorrelationIdf950c205-1e7e-4e44-b0a9-547eb3af65fc",
+        "externalVersion": 96,
+        "code": "Code016aa499-5a17-4edd-8e64-2c2d75691517",
+        "message": "Message36c8ec31-e8c7-4e3b-bcac-036bb4b6661f"
       },
       {
-        "code": "Codef0b58749-eb9b-483d-97b6-6715fd2d0ca1",
-        "message": "Message373f1ed1-3c0a-49ac-89ae-a07fe8f7c8d6"
+        "externalCorrelationId": "ExternalCorrelationId432c16a0-7c4e-4fb8-9501-d7034e9fa815",
+        "externalVersion": 15,
+        "code": "Codedde5aff0-d7f8-49cc-a1d7-1e1deab4ff02",
+        "message": "Messagef476e9aa-e398-4b43-9a8b-5c75ce36ff4a"
       }
     ]
   },

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -344,22 +344,58 @@
   "inboundError": {
     "notifications": [
       {
-        "externalCorrelationId": "ExternalCorrelationId1876c2e7-36e8-4704-b2c6-b5e96e2f117b",
-        "externalVersion": 230,
-        "code": "Code2ae97016-7148-47c6-820d-6bca40482b0a",
-        "message": "Messageb56851be-4e82-48de-ad19-62ffa7833e2b"
+        "externalCorrelationId": "ExternalCorrelationId5a0fb6fd-70ef-4159-a8ca-51455cab6016",
+        "externalVersion": 194,
+        "errors": [
+          {
+            "code": "Code05d73f4c-48da-4c60-b677-2dc8160bd332",
+            "message": "Message82f30258-65e0-4d59-b50c-4b8c9403974e"
+          },
+          {
+            "code": "Code5a17896c-1e03-4c0b-bafd-767772abf733",
+            "message": "Message30956315-6693-461e-82e7-31832ab96b75"
+          },
+          {
+            "code": "Codef9127674-2924-44a6-aa27-f771fbd9ecac",
+            "message": "Message1702ffe6-bbaa-4386-8edf-c1a1ad6fc3c0"
+          }
+        ]
       },
       {
-        "externalCorrelationId": "ExternalCorrelationIdf950c205-1e7e-4e44-b0a9-547eb3af65fc",
-        "externalVersion": 96,
-        "code": "Code016aa499-5a17-4edd-8e64-2c2d75691517",
-        "message": "Message36c8ec31-e8c7-4e3b-bcac-036bb4b6661f"
+        "externalCorrelationId": "ExternalCorrelationIdb19e0c33-34b2-446f-aae2-934a50c5472e",
+        "externalVersion": 170,
+        "errors": [
+          {
+            "code": "Codee681e46c-e169-4667-99f0-e7cad24ae9fa",
+            "message": "Message1d569ca4-ce24-4a88-a365-298e630b484a"
+          },
+          {
+            "code": "Coded44ab4e5-9f30-49b8-9029-a29b1b68ed20",
+            "message": "Message46868672-47e2-4873-b0f6-aa5c94f90f8d"
+          },
+          {
+            "code": "Codee4d8c3b1-0f57-489c-aa33-856312cfa9e6",
+            "message": "Messagee3938997-64fe-4830-8b53-daeb510c163d"
+          }
+        ]
       },
       {
-        "externalCorrelationId": "ExternalCorrelationId432c16a0-7c4e-4fb8-9501-d7034e9fa815",
-        "externalVersion": 15,
-        "code": "Codedde5aff0-d7f8-49cc-a1d7-1e1deab4ff02",
-        "message": "Messagef476e9aa-e398-4b43-9a8b-5c75ce36ff4a"
+        "externalCorrelationId": "ExternalCorrelationId4475cf43-6aba-4c98-a0ca-13357a85abb1",
+        "externalVersion": 108,
+        "errors": [
+          {
+            "code": "Code9e3906b5-f906-4b50-9087-0c7e8ec7ea83",
+            "message": "Message5b28bfb2-73be-4be8-a408-7e909f8868f5"
+          },
+          {
+            "code": "Codec6335c38-8f1b-4423-9cb4-2b7af184d0c2",
+            "message": "Messaged19a819e-c0b0-4f24-9830-894782c485e3"
+          },
+          {
+            "code": "Code01c7adcc-98ed-452d-93de-171f926a051b",
+            "message": "Messagefecd9c5b-8818-45bc-b874-f43ccdeb59c2"
+          }
+        ]
       }
     ]
   },

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.cs
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.cs
@@ -102,7 +102,8 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
         var customsDeclaration = fixture.Create<CustomsDeclaration>();
         var serialized = JsonSerializer.Serialize(customsDeclaration, s_jsonOptions);
 
-        // Take this file and replace GetTests_DomainExample.json when needed
+        // Take this file and replace GetTests_DomainExample.json when needed or
+        // take the parts that have changed/been added to minimise the amount of unnecessary changes
         await File.WriteAllTextAsync(
             $"{nameof(Get_WhenGenerating_GetTests_DomainExample_ShouldSerialize)}_CustomsDeclaration.json",
             serialized
@@ -129,6 +130,7 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
                     ClearanceRequest = customsDeclaration.ClearanceRequest,
                     ClearanceDecision = customsDeclaration.ClearanceDecision,
                     Finalisation = customsDeclaration.Finalisation,
+                    InboundError = customsDeclaration.InboundError,
                     Created = new DateTime(2025, 4, 3, 10, 0, 0, DateTimeKind.Utc),
                     Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
                     ETag = "etag",

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
@@ -341,20 +341,24 @@
     "isManualRelease": true
   },
   "InboundError": {
-    "externalCorrelationId": "ExternalCorrelationId6aeab374-36e3-4baf-85d0-11a1b9ed39df",
-    "externalVersion": 237,
-    "errors": [
+    "notifications": [
       {
-        "code": "Code608891fd-f4e4-482d-9466-8a0767eaa29d",
-        "message": "Message714fdb0d-68ff-4500-a663-3266bacf2730"
+        "externalCorrelationId": "ExternalCorrelationId1876c2e7-36e8-4704-b2c6-b5e96e2f117b",
+        "externalVersion": 230,
+        "code": "Code2ae97016-7148-47c6-820d-6bca40482b0a",
+        "message": "Messageb56851be-4e82-48de-ad19-62ffa7833e2b"
       },
       {
-        "code": "Code7028e97f-2bf9-48fb-8fc5-b595f0a923e2",
-        "message": "Messageae1a5bf5-a246-492e-8af8-99cc380ad892"
+        "externalCorrelationId": "ExternalCorrelationIdf950c205-1e7e-4e44-b0a9-547eb3af65fc",
+        "externalVersion": 96,
+        "code": "Code016aa499-5a17-4edd-8e64-2c2d75691517",
+        "message": "Message36c8ec31-e8c7-4e3b-bcac-036bb4b6661f"
       },
       {
-        "code": "Codef0b58749-eb9b-483d-97b6-6715fd2d0ca1",
-        "message": "Message373f1ed1-3c0a-49ac-89ae-a07fe8f7c8d6"
+        "externalCorrelationId": "ExternalCorrelationId432c16a0-7c4e-4fb8-9501-d7034e9fa815",
+        "externalVersion": 15,
+        "code": "Codedde5aff0-d7f8-49cc-a1d7-1e1deab4ff02",
+        "message": "Messagef476e9aa-e398-4b43-9a8b-5c75ce36ff4a"
       }
     ]
   }

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
@@ -339,5 +339,23 @@
     "decisionNumber": 231,
     "finalState": 0,
     "isManualRelease": true
+  },
+  "InboundError": {
+    "externalCorrelationId": "ExternalCorrelationId6aeab374-36e3-4baf-85d0-11a1b9ed39df",
+    "externalVersion": 237,
+    "errors": [
+      {
+        "code": "Code608891fd-f4e4-482d-9466-8a0767eaa29d",
+        "message": "Message714fdb0d-68ff-4500-a663-3266bacf2730"
+      },
+      {
+        "code": "Code7028e97f-2bf9-48fb-8fc5-b595f0a923e2",
+        "message": "Messageae1a5bf5-a246-492e-8af8-99cc380ad892"
+      },
+      {
+        "code": "Codef0b58749-eb9b-483d-97b6-6715fd2d0ca1",
+        "message": "Message373f1ed1-3c0a-49ac-89ae-a07fe8f7c8d6"
+      }
+    ]
   }
 }

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
@@ -343,22 +343,58 @@
   "InboundError": {
     "notifications": [
       {
-        "externalCorrelationId": "ExternalCorrelationId1876c2e7-36e8-4704-b2c6-b5e96e2f117b",
-        "externalVersion": 230,
-        "code": "Code2ae97016-7148-47c6-820d-6bca40482b0a",
-        "message": "Messageb56851be-4e82-48de-ad19-62ffa7833e2b"
+        "externalCorrelationId": "ExternalCorrelationId5a0fb6fd-70ef-4159-a8ca-51455cab6016",
+        "externalVersion": 194,
+        "errors": [
+          {
+            "code": "Code05d73f4c-48da-4c60-b677-2dc8160bd332",
+            "message": "Message82f30258-65e0-4d59-b50c-4b8c9403974e"
+          },
+          {
+            "code": "Code5a17896c-1e03-4c0b-bafd-767772abf733",
+            "message": "Message30956315-6693-461e-82e7-31832ab96b75"
+          },
+          {
+            "code": "Codef9127674-2924-44a6-aa27-f771fbd9ecac",
+            "message": "Message1702ffe6-bbaa-4386-8edf-c1a1ad6fc3c0"
+          }
+        ]
       },
       {
-        "externalCorrelationId": "ExternalCorrelationIdf950c205-1e7e-4e44-b0a9-547eb3af65fc",
-        "externalVersion": 96,
-        "code": "Code016aa499-5a17-4edd-8e64-2c2d75691517",
-        "message": "Message36c8ec31-e8c7-4e3b-bcac-036bb4b6661f"
+        "externalCorrelationId": "ExternalCorrelationIdb19e0c33-34b2-446f-aae2-934a50c5472e",
+        "externalVersion": 170,
+        "errors": [
+          {
+            "code": "Codee681e46c-e169-4667-99f0-e7cad24ae9fa",
+            "message": "Message1d569ca4-ce24-4a88-a365-298e630b484a"
+          },
+          {
+            "code": "Coded44ab4e5-9f30-49b8-9029-a29b1b68ed20",
+            "message": "Message46868672-47e2-4873-b0f6-aa5c94f90f8d"
+          },
+          {
+            "code": "Codee4d8c3b1-0f57-489c-aa33-856312cfa9e6",
+            "message": "Messagee3938997-64fe-4830-8b53-daeb510c163d"
+          }
+        ]
       },
       {
-        "externalCorrelationId": "ExternalCorrelationId432c16a0-7c4e-4fb8-9501-d7034e9fa815",
-        "externalVersion": 15,
-        "code": "Codedde5aff0-d7f8-49cc-a1d7-1e1deab4ff02",
-        "message": "Messagef476e9aa-e398-4b43-9a8b-5c75ce36ff4a"
+        "externalCorrelationId": "ExternalCorrelationId4475cf43-6aba-4c98-a0ca-13357a85abb1",
+        "externalVersion": 108,
+        "errors": [
+          {
+            "code": "Code9e3906b5-f906-4b50-9087-0c7e8ec7ea83",
+            "message": "Message5b28bfb2-73be-4be8-a408-7e909f8868f5"
+          },
+          {
+            "code": "Codec6335c38-8f1b-4423-9cb4-2b7af184d0c2",
+            "message": "Messaged19a819e-c0b0-4f24-9830-894782c485e3"
+          },
+          {
+            "code": "Code01c7adcc-98ed-452d-93de-171f926a051b",
+            "message": "Messagefecd9c5b-8818-45bc-b874-f43ccdeb59c2"
+          }
+        ]
       }
     ]
   }

--- a/tests/Api.Tests/Endpoints/Gmrs/GetTests.cs
+++ b/tests/Api.Tests/Endpoints/Gmrs/GetTests.cs
@@ -127,7 +127,8 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
         var customsDeclaration = fixture.Create<Gmr>();
         var serialized = JsonSerializer.Serialize(customsDeclaration, s_jsonOptions);
 
-        // Take this file and replace GetTests_DomainExample.json when needed
+        // Take this file and replace GetTests_DomainExample.json when needed or
+        // take the parts that have changed/been added to minimise the amount of unnecessary changes
         await File.WriteAllTextAsync(
             $"{nameof(Get_WhenGenerating_GetTests_DomainExample_ShouldSerialize)}_Gmr.json",
             serialized

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetCustomsDeclarationsByChedIdTests.Get_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetCustomsDeclarationsByChedIdTests.Get_WhenFound_ShouldReturnContent.verified.txt
@@ -20,6 +20,7 @@
     },
     clearanceDecision: null,
     finalisation: null,
+    inboundError: null,
     created: 2025-04-03T10:00:00Z,
     updated: 2025-04-03T10:15:00Z
   }

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetTests.cs
@@ -105,7 +105,8 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
         var importPreNotification = fixture.Create<ImportPreNotification>();
         var serialized = JsonSerializer.Serialize(importPreNotification, s_jsonOptions);
 
-        // Take this file and replace GetTests_DomainExample.json when needed
+        // Take this file and replace GetTests_DomainExample.json when needed or
+        // take the parts that have changed/been added to minimise the amount of unnecessary changes
         await File.WriteAllTextAsync(
             $"{nameof(Get_WhenGenerating_GetTests_DomainExample_ShouldSerialize)}_ImportPreNotification.json",
             serialized

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -578,6 +578,14 @@
             ],
             "nullable": true
           },
+          "inboundError": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundError"
+              }
+            ],
+            "nullable": true
+          },
           "created": {
             "type": "string",
             "format": "date-time"
@@ -908,6 +916,14 @@
               }
             ],
             "nullable": true
+          },
+          "inboundError": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundError"
+              }
+            ],
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -998,6 +1014,42 @@
         "type": "object",
         "properties": {
           "value": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundError": {
+        "type": "object",
+        "properties": {
+          "externalCorrelationId": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalVersion": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorItem"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorItem": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
             "type": "string",
             "nullable": true
           }

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1023,6 +1023,19 @@
       "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundError": {
         "type": "object",
         "properties": {
+          "notifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorNotification"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorNotification": {
+        "type": "object",
+        "properties": {
           "externalCorrelationId": {
             "type": "string",
             "nullable": true
@@ -1032,19 +1045,6 @@
             "format": "int32",
             "nullable": true
           },
-          "errors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorItem"
-            },
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
-      "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorItem": {
-        "type": "object",
-        "properties": {
           "code": {
             "type": "string",
             "nullable": true

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1033,6 +1033,20 @@
         },
         "additionalProperties": false
       },
+      "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorItem": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorNotification": {
         "type": "object",
         "properties": {
@@ -1045,12 +1059,11 @@
             "format": "int32",
             "nullable": true
           },
-          "code": {
-            "type": "string",
-            "nullable": true
-          },
-          "message": {
-            "type": "string",
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.InboundErrorItem"
+            },
             "nullable": true
           }
         },

--- a/tests/Api.Tests/Services/ResourceEventExtensionsTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventExtensionsTests.cs
@@ -103,8 +103,18 @@ public class ResourceEventExtensionsTests
     public void WhenWithChangeSet_AndSubResourceTypeIsClearanceRequest_ShouldSetSubResourceType()
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };
-        var previous = new CustomsDeclarationData(ClearanceRequest: null, ClearanceDecision: null, Finalisation: null);
-        var current = new CustomsDeclarationData(new ClearanceRequest(), ClearanceDecision: null, Finalisation: null);
+        var previous = new CustomsDeclarationData(
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null
+        );
+        var current = new CustomsDeclarationData(
+            new ClearanceRequest(),
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null
+        );
 
         var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
 
@@ -118,12 +128,14 @@ public class ResourceEventExtensionsTests
         var previous = new CustomsDeclarationData(
             new ClearanceRequest { ExternalVersion = 1 },
             ClearanceDecision: null,
-            Finalisation: null
+            Finalisation: null,
+            InboundError: null
         );
         var current = new CustomsDeclarationData(
             new ClearanceRequest { ExternalVersion = 2 },
             ClearanceDecision: null,
-            Finalisation: null
+            Finalisation: null,
+            InboundError: null
         );
 
         var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
@@ -135,11 +147,17 @@ public class ResourceEventExtensionsTests
     public void WhenWithChangeSet_AndSubResourceTypeIsClearanceDecision_ShouldSetSubResourceType()
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };
-        var previous = new CustomsDeclarationData(ClearanceRequest: null, ClearanceDecision: null, Finalisation: null);
+        var previous = new CustomsDeclarationData(
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null
+        );
         var current = new CustomsDeclarationData(
             ClearanceRequest: null,
             new ClearanceDecision { Items = [] },
-            Finalisation: null
+            Finalisation: null,
+            InboundError: null
         );
 
         var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
@@ -151,7 +169,12 @@ public class ResourceEventExtensionsTests
     public void WhenWithChangeSet_AndSubResourceTypeIsFinalisation_ShouldSetSubResourceType()
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };
-        var previous = new CustomsDeclarationData(ClearanceRequest: null, ClearanceDecision: null, Finalisation: null);
+        var previous = new CustomsDeclarationData(
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null
+        );
         var current = new CustomsDeclarationData(
             ClearanceRequest: null,
             ClearanceDecision: null,
@@ -160,7 +183,8 @@ public class ResourceEventExtensionsTests
                 ExternalVersion = 0,
                 FinalState = FinalState.Cleared,
                 IsManualRelease = false,
-            }
+            },
+            InboundError: null
         );
 
         var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
@@ -169,10 +193,37 @@ public class ResourceEventExtensionsTests
     }
 
     [Fact]
+    public void WhenWithChangeSet_AndSubResourceTypeIsInboundError_ShouldSetSubResourceType()
+    {
+        var subject = new FixtureEntity { Id = "id", ETag = "etag" };
+        var previous = new CustomsDeclarationData(
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null
+        );
+        var current = new CustomsDeclarationData(
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: new InboundError()
+        );
+
+        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+
+        result.SubResourceType.Should().Be("InboundError");
+    }
+
+    [Fact]
     public void WhenWithChangeSet_AndMultipleKnownSubResourceTypes_ShouldThrow()
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };
-        var previous = new CustomsDeclarationData(ClearanceRequest: null, ClearanceDecision: null, Finalisation: null);
+        var previous = new CustomsDeclarationData(
+            ClearanceRequest: null,
+            ClearanceDecision: null,
+            Finalisation: null,
+            InboundError: null
+        );
         var current = new CustomsDeclarationData(
             new ClearanceRequest(),
             new ClearanceDecision { Items = [] },
@@ -181,7 +232,8 @@ public class ResourceEventExtensionsTests
                 ExternalVersion = 0,
                 FinalState = FinalState.Cleared,
                 IsManualRelease = false,
-            }
+            },
+            InboundError: null
         );
 
         var act = () => subject.ToResourceEvent("operation").WithChangeSet(current, previous);
@@ -210,6 +262,7 @@ public class ResourceEventExtensionsTests
     private sealed record CustomsDeclarationData(
         ClearanceRequest? ClearanceRequest,
         ClearanceDecision? ClearanceDecision,
-        Finalisation? Finalisation
+        Finalisation? Finalisation,
+        InboundError? InboundError
     );
 }

--- a/tests/Api.Tests/Services/ResourceEventPublisherTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventPublisherTests.cs
@@ -6,6 +6,7 @@ using Defra.TradeImportsDataApi.Api.Utils.Logging;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.Events;
 using Microsoft.AspNetCore.HeaderPropagation;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using NSubstitute;
@@ -24,7 +25,8 @@ public class ResourceEventPublisherTests
             new HeaderPropagationValues(),
             new OptionsWrapper<ResourceEventOptions>(
                 new ResourceEventOptions { ArnPrefix = "arn", TopicName = "topic-name" }
-            )
+            ),
+            NullLogger<ResourceEventPublisher>.Instance
         );
 
         await subject.Publish(
@@ -63,7 +65,8 @@ public class ResourceEventPublisherTests
             headerPropagationValues,
             new OptionsWrapper<ResourceEventOptions>(
                 new ResourceEventOptions { ArnPrefix = "arn", TopicName = "topic-name" }
-            )
+            ),
+            NullLogger<ResourceEventPublisher>.Instance
         );
 
         headerPropagationValues.Headers = new Dictionary<string, StringValues> { { "trace-id", "trace-id-value" } };
@@ -99,7 +102,8 @@ public class ResourceEventPublisherTests
             new HeaderPropagationValues(),
             new OptionsWrapper<ResourceEventOptions>(
                 new ResourceEventOptions { ArnPrefix = "arn", TopicName = "topic-name" }
-            )
+            ),
+            NullLogger<ResourceEventPublisher>.Instance
         );
 
         await subject.Publish(


### PR DESCRIPTION
This PR adds support for inbound errors stored against the customs declaration.

Domain structure is as follows:

```c#
public class InboundError
{
    [JsonPropertyName("notifications")]
    public InboundErrorNotification[]? Notifications { get; set; }
}

public class InboundErrorNotification
{
    [JsonPropertyName("externalCorrelationId")]
    public string? ExternalCorrelationId { get; set; }

    [JsonPropertyName("externalVersion")]
    public int? ExternalVersion { get; set; }
    
    [JsonPropertyName("errors")]
    public InboundErrorNotificationItem[]? Errors { get; set; }
}

public class InboundErrorNotificationItem
{
    [JsonPropertyName("code")]
    public string? Code { get; set; }

    [JsonPropertyName("message")]
    public string? Message { get; set; }
}
```

~~Update to a pre release of version 0.10.0 of the API client and test the processor mapping to ensure all is OK.~~

This has now been integrated therefore we can merge.