### PR TITLE
Include a change set one entity creation, which will then set the sub resource type

### DIFF
--- a/src/Api/Services/CustomsDeclarationService.cs
+++ b/src/Api/Services/CustomsDeclarationService.cs
@@ -24,7 +24,16 @@ public class CustomsDeclarationService(IDbContext dbContext, IResourceEventPubli
         await dbContext.CustomsDeclarations.Insert(customsDeclarationEntity, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         await resourceEventPublisher.Publish(
-            customsDeclarationEntity.ToResourceEvent(ResourceEventOperations.Created),
+            customsDeclarationEntity
+                .ToResourceEvent(ResourceEventOperations.Created)
+                .WithChangeSet(
+                    new CustomsDeclarationData(
+                        customsDeclarationEntity.ClearanceRequest,
+                        customsDeclarationEntity.ClearanceDecision,
+                        customsDeclarationEntity.Finalisation
+                    ),
+                    CustomsDeclarationData.Empty
+                ),
             cancellationToken
         );
 
@@ -84,5 +93,9 @@ public class CustomsDeclarationService(IDbContext dbContext, IResourceEventPubli
         ClearanceRequest? ClearanceRequest,
         ClearanceDecision? ClearanceDecision,
         Finalisation? Finalisation
-    );
+    )
+    {
+        public static CustomsDeclarationData Empty =>
+            new(ClearanceRequest: null, ClearanceDecision: null, Finalisation: null);
+    }
 }

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -2,6 +2,7 @@ using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.Events;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using MongoDB.Driver.Linq;
 
 namespace Defra.TradeImportsDataApi.Api.Services;
@@ -40,7 +41,9 @@ public class ImportPreNotificationService(IDbContext dbContext, IResourceEventPu
         await dbContext.ImportPreNotifications.Insert(importPreNotificationEntity, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         await resourceEventPublisher.Publish(
-            importPreNotificationEntity.ToResourceEvent(ResourceEventOperations.Created),
+            importPreNotificationEntity
+                .ToResourceEvent(ResourceEventOperations.Created)
+                .WithChangeSet(importPreNotificationEntity.ImportPreNotification, new ImportPreNotification()),
             cancellationToken
         );
 

--- a/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
+++ b/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
@@ -27,7 +27,9 @@ public class CustomsDeclarationServiceTests
         await mockResourceEventPublisher
             .Received()
             .Publish(
-                Arg.Is<ResourceEvent<CustomsDeclarationEntity>>(x => x.Operation == "Created"),
+                Arg.Is<ResourceEvent<CustomsDeclarationEntity>>(x =>
+                    x.Operation == "Created" && x.ChangeSet.Count > 0 && x.SubResourceType != null
+                ),
                 CancellationToken.None
             );
     }
@@ -74,7 +76,9 @@ public class CustomsDeclarationServiceTests
         await mockResourceEventPublisher
             .Received()
             .Publish(
-                Arg.Is<ResourceEvent<CustomsDeclarationEntity>>(x => x.Operation == "Updated" && x.ChangeSet.Count > 0),
+                Arg.Is<ResourceEvent<CustomsDeclarationEntity>>(x =>
+                    x.Operation == "Updated" && x.ChangeSet.Count > 0 && x.SubResourceType != null
+                ),
                 CancellationToken.None
             );
     }

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -17,7 +17,11 @@ public class ImportPreNotificationServiceTests
         var mockDbContext = Substitute.For<IDbContext>();
         var mockResourceEventPublisher = Substitute.For<IResourceEventPublisher>();
         var subject = new ImportPreNotificationService(mockDbContext, mockResourceEventPublisher);
-        var entity = new ImportPreNotificationEntity { Id = "id", ImportPreNotification = new ImportPreNotification() };
+        var entity = new ImportPreNotificationEntity
+        {
+            Id = "id",
+            ImportPreNotification = new ImportPreNotification { Version = 1 },
+        };
 
         await subject.Insert(entity, CancellationToken.None);
 
@@ -26,7 +30,9 @@ public class ImportPreNotificationServiceTests
         await mockResourceEventPublisher
             .Received()
             .Publish(
-                Arg.Is<ResourceEvent<ImportPreNotificationEntity>>(x => x.Operation == "Created"),
+                Arg.Is<ResourceEvent<ImportPreNotificationEntity>>(x =>
+                    x.Operation == "Created" && x.ChangeSet.Count > 0
+                ),
                 CancellationToken.None
             );
     }


### PR DESCRIPTION
We saw in testing that sub resource type is not being set on entity creation. Sub resource type is set during change set creation therefore produce a change set on entity creation too.

For now, we don't know for definite if we want to do this long term but for now it seems reasonable.