### PR TITLE
Add nullable message for generic error if needed

### DIFF
--- a/src/Api.Client/Api.Client.csproj
+++ b/src/Api.Client/Api.Client.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Api.Client</PackageId>
-    <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Client</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Domain</PackageId>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Domain</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Errors/ErrorNotification.cs
+++ b/src/Domain/Errors/ErrorNotification.cs
@@ -12,4 +12,7 @@ public class ErrorNotification
 
     [JsonPropertyName("errors")]
     public ErrorItem[] Errors { get; set; } = [];
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
 }

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -26,12 +26,4 @@
   <ItemGroup>
     <EmbeddedResource Include="Endpoints\*\*.json" />
   </ItemGroup>
-  <ItemGroup>
-    <None Update="Endpoints\Search\RelatedImportDeclarationsTests.Search_WhenFound_ShouldReturnContent.verified.txt">
-      <DependentUpon>RelatedImportDeclarationsTests.cs</DependentUpon>
-    </None>
-    <None Update="Endpoints\Search\RelatedImportDeclarationsTests.Search_WhenFound_ShouldReturnContent_response.verified.txt">
-      <DependentUpon>RelatedImportDeclarationsTests.cs</DependentUpon>
-    </None>
-  </ItemGroup>
 </Project>

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -359,7 +359,8 @@
             "code": "Codef9127674-2924-44a6-aa27-f771fbd9ecac",
             "message": "Message1702ffe6-bbaa-4386-8edf-c1a1ad6fc3c0"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82d7"
       },
       {
         "externalCorrelationId": "ExternalCorrelationIdb19e0c33-34b2-446f-aae2-934a50c5472e",
@@ -377,7 +378,8 @@
             "code": "Codee4d8c3b1-0f57-489c-aa33-856312cfa9e6",
             "message": "Messagee3938997-64fe-4830-8b53-daeb510c163d"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82d8"
       },
       {
         "externalCorrelationId": "ExternalCorrelationId4475cf43-6aba-4c98-a0ca-13357a85abb1",
@@ -395,7 +397,8 @@
             "code": "Code01c7adcc-98ed-452d-93de-171f926a051b",
             "message": "Messagefecd9c5b-8818-45bc-b874-f43ccdeb59c2"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82d9"
       }
     ]
   },

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
@@ -358,7 +358,8 @@
             "code": "Codef9127674-2924-44a6-aa27-f771fbd9ecac",
             "message": "Message1702ffe6-bbaa-4386-8edf-c1a1ad6fc3c0"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82d7"
       },
       {
         "externalCorrelationId": "ExternalCorrelationIdb19e0c33-34b2-446f-aae2-934a50c5472e",
@@ -376,7 +377,8 @@
             "code": "Codee4d8c3b1-0f57-489c-aa33-856312cfa9e6",
             "message": "Messagee3938997-64fe-4830-8b53-daeb510c163d"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82d8"
       },
       {
         "externalCorrelationId": "ExternalCorrelationId4475cf43-6aba-4c98-a0ca-13357a85abb1",
@@ -394,7 +396,8 @@
             "code": "Code01c7adcc-98ed-452d-93de-171f926a051b",
             "message": "Messagefecd9c5b-8818-45bc-b874-f43ccdeb59c2"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82d9"
       }
     ]
   }

--- a/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -18,7 +18,8 @@
             "code": "Code39617846-afb3-4850-b0bc-70bbc63ca93c",
             "message": "Messagef3e9a4e0-a10a-4b6d-8ec5-b7083d4b2f68"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82c3"
       },
       {
         "externalCorrelationId": "ExternalCorrelationIdbcb39365-a337-42ac-bdee-94613207ad4f",
@@ -36,7 +37,8 @@
             "code": "Code957a89a0-23cb-4f3f-b1a6-8234f879213c",
             "message": "Message864cf362-38f8-4ce9-b648-7ed8066d83a0"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82c1"
       },
       {
         "externalCorrelationId": "ExternalCorrelationIdca508e72-10f6-4b67-8c36-312d6b0678ca",
@@ -54,7 +56,8 @@
             "code": "Code9d3f6fd1-9a1e-44f9-98df-6a9a20de2c13",
             "message": "Message6f51b234-5938-4ef8-870c-8cede2ccf9ec"
           }
-        ]
+        ],
+        "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82c2"
       }
     ]
   },

--- a/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests_DomainExample.json
@@ -16,7 +16,8 @@
           "code": "Code39617846-afb3-4850-b0bc-70bbc63ca93c",
           "message": "Messagef3e9a4e0-a10a-4b6d-8ec5-b7083d4b2f68"
         }
-      ]
+      ],
+      "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82c3"
     },
     {
       "externalCorrelationId": "ExternalCorrelationIdbcb39365-a337-42ac-bdee-94613207ad4f",
@@ -34,7 +35,8 @@
           "code": "Code957a89a0-23cb-4f3f-b1a6-8234f879213c",
           "message": "Message864cf362-38f8-4ce9-b648-7ed8066d83a0"
         }
-      ]
+      ],
+      "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82c1"
     },
     {
       "externalCorrelationId": "ExternalCorrelationIdca508e72-10f6-4b67-8c36-312d6b0678ca",
@@ -52,7 +54,8 @@
           "code": "Code9d3f6fd1-9a1e-44f9-98df-6a9a20de2c13",
           "message": "Message6f51b234-5938-4ef8-870c-8cede2ccf9ec"
         }
-      ]
+      ],
+      "message": "Message15ed54b7-4573-40bb-8236-902dcf1a82c2"
     }
   ]
 }

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1306,6 +1306,10 @@
               "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.Errors.ErrorItem"
             },
             "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
Allows a generic error to be saved or input from another system that we want to capture, such as messages from CDS.