### PR TITLE
Add created date for error notification

### DIFF
--- a/src/Api.Client/Api.Client.csproj
+++ b/src/Api.Client/Api.Client.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Api.Client</PackageId>
-    <VersionPrefix>0.14.0</VersionPrefix>
+    <VersionPrefix>0.15.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Client</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Domain</PackageId>
-    <VersionPrefix>0.12.0</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Domain</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Errors/ErrorNotification.cs
+++ b/src/Domain/Errors/ErrorNotification.cs
@@ -10,6 +10,9 @@ public class ErrorNotification
     [JsonPropertyName("externalVersion")]
     public int? ExternalVersion { get; set; }
 
+    [JsonPropertyName("created")]
+    public DateTime? Created { get; set; }
+
     [JsonPropertyName("errors")]
     public ErrorItem[] Errors { get; set; } = [];
 

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -346,6 +346,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationId5a0fb6fd-70ef-4159-a8ca-51455cab6016",
         "externalVersion": 194,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Code05d73f4c-48da-4c60-b677-2dc8160bd332",
@@ -365,6 +366,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationIdb19e0c33-34b2-446f-aae2-934a50c5472e",
         "externalVersion": 170,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Codee681e46c-e169-4667-99f0-e7cad24ae9fa",
@@ -384,6 +386,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationId4475cf43-6aba-4c98-a0ca-13357a85abb1",
         "externalVersion": 108,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Code9e3906b5-f906-4b50-9087-0c7e8ec7ea83",

--- a/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/CustomsDeclarations/GetTests_DomainExample.json
@@ -345,6 +345,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationId5a0fb6fd-70ef-4159-a8ca-51455cab6016",
         "externalVersion": 194,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Code05d73f4c-48da-4c60-b677-2dc8160bd332",
@@ -364,6 +365,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationIdb19e0c33-34b2-446f-aae2-934a50c5472e",
         "externalVersion": 170,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Codee681e46c-e169-4667-99f0-e7cad24ae9fa",
@@ -383,6 +385,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationId4475cf43-6aba-4c98-a0ca-13357a85abb1",
         "externalVersion": 108,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Code9e3906b5-f906-4b50-9087-0c7e8ec7ea83",

--- a/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
+++ b/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests.Get_WhenReturningDomainExample_ShouldBeCorrectJson.verified.json
@@ -5,6 +5,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationId815625eb-3e33-460b-af4f-a5e5f23da033",
         "externalVersion": 36,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Codebdc575a2-600d-4e93-895f-5055e57405a1",
@@ -24,6 +25,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationIdbcb39365-a337-42ac-bdee-94613207ad4f",
         "externalVersion": 206,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Code4b0de721-01df-4075-99cd-92cac951c4f7",
@@ -43,6 +45,7 @@
       {
         "externalCorrelationId": "ExternalCorrelationIdca508e72-10f6-4b67-8c36-312d6b0678ca",
         "externalVersion": 32,
+        "created": "2026-03-19T09:36:58.823352",
         "errors": [
           {
             "code": "Code6955771e-7e21-4bfc-a7f1-d5e4715519c6",

--- a/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests_DomainExample.json
+++ b/tests/Api.Tests/Endpoints/ProcessingErrors/GetTests_DomainExample.json
@@ -3,6 +3,7 @@
     {
       "externalCorrelationId": "ExternalCorrelationId815625eb-3e33-460b-af4f-a5e5f23da033",
       "externalVersion": 36,
+      "created": "2026-03-19T09:36:58.823352",
       "errors": [
         {
           "code": "Codebdc575a2-600d-4e93-895f-5055e57405a1",
@@ -22,6 +23,7 @@
     {
       "externalCorrelationId": "ExternalCorrelationIdbcb39365-a337-42ac-bdee-94613207ad4f",
       "externalVersion": 206,
+      "created": "2026-03-19T09:36:58.823352",
       "errors": [
         {
           "code": "Code4b0de721-01df-4075-99cd-92cac951c4f7",
@@ -41,6 +43,7 @@
     {
       "externalCorrelationId": "ExternalCorrelationIdca508e72-10f6-4b67-8c36-312d6b0678ca",
       "externalVersion": 32,
+      "created": "2026-03-19T09:36:58.823352",
       "errors": [
         {
           "code": "Code6955771e-7e21-4bfc-a7f1-d5e4715519c6",

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1308,6 +1308,11 @@
             "format": "int32",
             "nullable": true
           },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
           "errors": {
             "type": "array",
             "items": {


### PR DESCRIPTION
During testing, it was hard to see what the created date for error notifications was if there were multiple for the same version. Beyond the correlation ID, a created date would help.

This PR adds just that!