### PR TITLE
Test grouping AWSSDK revisions together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       timezone: "Europe/London"
     # Single PR for patch and minor
     # Major will be one update per PR
+    # AWSSDK updates to group revisions
     groups:
       patch:
         update-types:
@@ -17,6 +18,11 @@ updates:
       minor:
         update-types:
           - "minor"
+      aws-sdk-revision:
+        patterns:
+          - "AWSSDK.*"
+        update-types:
+          - "version-update:semver-patch"
     allow:
       - dependency-type: direct
 


### PR DESCRIPTION
Cannot test this until it's merged so may revert if it does not have the desired effect. 

Currently, as AWS SDK updates are using 4 part version numbers, revision updates are coming through as single PRs, which is frustrating and can break things if they're not updated in unison.

This PR attempts to group all AWSSDK.* revision updates together.