### PR TITLE
Change group so it's all AWS SDK as previous update type was not valid

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       timezone: "Europe/London"
     # Single PR for patch and minor
     # Major will be one update per PR
-    # AWSSDK updates to group revisions
+    # AWS SDK updates no matter what update type
     groups:
       patch:
         update-types:
@@ -18,11 +18,9 @@ updates:
       minor:
         update-types:
           - "minor"
-      aws-sdk-revision:
+      aws-sdk:
         patterns:
           - "AWSSDK.*"
-        update-types:
-          - "version-update:semver-patch"
     allow:
       - dependency-type: direct
 


### PR DESCRIPTION
Second attempt for dependabot and AWS SDK.