### PR TITLE
Update dependencies where possible - v4 of AWS cannot be used yet as MongoDB.Driver.Authentication.AWS is still tracking a v3 transient dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.8.0.113526">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.9.0.115408">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.138" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.400.147" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="8.12.3" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="8.12.3" />
     <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.4" />

--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
-    <PackageReference Include="MongoDB.Driver.Authentication.AWS" Version="3.3.0" />
+    <PackageReference Include="MongoDB.Driver.Authentication.AWS" Version="3.4.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/tests/Api.Client.Tests/Api.Client.Tests.csproj
+++ b/tests/Api.Client.Tests/Api.Client.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -12,10 +12,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.138" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.400.147" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Api.IntegrationTests/Endpoints/CustomsDeclarationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/CustomsDeclarationTests.cs
@@ -1,10 +1,11 @@
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using FluentAssertions;
+using Xunit.Abstractions;
 
 namespace Defra.TradeImportsDataApi.Api.IntegrationTests.Endpoints;
 
-public class CustomsDeclarationTests : SqsTestBase
+public class CustomsDeclarationTests(ITestOutputHelper testOutputHelper) : SqsTestBase(testOutputHelper)
 {
     [Fact]
     public async Task WhenDoesNotExist_ShouldCreateAndRead()

--- a/tests/Api.IntegrationTests/Endpoints/ImportPreNotificationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportPreNotificationTests.cs
@@ -2,10 +2,11 @@ using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using Defra.TradeImportsDataApi.Testing;
 using FluentAssertions;
+using Xunit.Abstractions;
 
 namespace Defra.TradeImportsDataApi.Api.IntegrationTests.Endpoints;
 
-public class ImportPreNotificationTests : SqsTestBase
+public class ImportPreNotificationTests(ITestOutputHelper testOutputHelper) : SqsTestBase(testOutputHelper)
 {
     [Fact]
     public async Task WhenDoesNotExist_ShouldCreateAndRead()

--- a/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.cs
@@ -1,10 +1,11 @@
 using Defra.TradeImportsDataApi.Domain.Errors;
 using Defra.TradeImportsDataApi.Domain.ProcessingErrors;
 using FluentAssertions;
+using Xunit.Abstractions;
 
 namespace Defra.TradeImportsDataApi.Api.IntegrationTests.Endpoints;
 
-public class ProcessingErrorTests : SqsTestBase
+public class ProcessingErrorTests(ITestOutputHelper testOutputHelper) : SqsTestBase(testOutputHelper)
 {
     [Fact]
     public async Task WhenDoesNotExist_ShouldCreateAndRead()

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Data.Tests/Data.Tests.csproj
+++ b/tests/Data.Tests/Data.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Domain.Tests/Domain.Tests.csproj
+++ b/tests/Domain.Tests/Domain.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Testing/Testing.csproj
+++ b/tests/Testing/Testing.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -20,10 +20,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.7.4" />
+    <PackageReference Include="WireMock.Net.FluentAssertions" Version="1.8.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="29.3.0" />
+    <PackageReference Include="Verify.Xunit" Version="30.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />


### PR DESCRIPTION
As per PR title.

Dependabot is missing some updates and not sure why. These changes bring the service as up to date as possible.

I saw a failure initially in both the pipeline and locally when running integration tests. Messages could not be drained quick enough, hence the additional diagnostic logs and setting the receive message params so things happen quicker.