### PR TITLE
Remove disable of auth based on running DEVELOPMENT mode

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -42,6 +42,9 @@ services:
       Mongo__DatabaseUri: mongodb://mongodb:27017/?directConnection=true
       AWS__ServiceUrl: http://localstack:4566
       AWS__AuthenticationRegion: eu-west-2
+      Acl__Clients__IntegrationTests__Secret: integration-tests-pwd
+      Acl__Clients__IntegrationTests__Scopes__0: read
+      Acl__Clients__IntegrationTests__Scopes__1: write
     ports:
       - "8080:8080"
     healthcheck:

--- a/src/Api/Endpoints/CustomsDeclarations/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/CustomsDeclarations/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 using Defra.TradeImportsDataApi.Api.Exceptions;
@@ -13,11 +12,11 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 
 public static class EndpointRouteBuilderExtensions
 {
-    public static void MapCustomsDeclarationEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    public static void MapCustomsDeclarationEndpoints(this IEndpointRouteBuilder app)
     {
         const string groupName = "CustomsDeclarations";
 
-        var route = app.MapGet("customs-declarations/{mrn}/", Get)
+        app.MapGet("customs-declarations/{mrn}/", Get)
             .WithName("CustomsDeclarationByMrn")
             .WithTags(groupName)
             .WithSummary("Get CustomsDeclaration")
@@ -27,9 +26,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
 
-        AllowAnonymousForDevelopment(isDevelopment, route);
-
-        route = app.MapGet("customs-declarations/{mrn}/import-pre-notifications", GetImportPreNotifications)
+        app.MapGet("customs-declarations/{mrn}/import-pre-notifications", GetImportPreNotifications)
             .WithName("ImportPreNotificationsByMrn")
             .WithTags(groupName)
             .WithSummary("Get ImportPreNotifications by MRN")
@@ -39,9 +36,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
 
-        AllowAnonymousForDevelopment(isDevelopment, route);
-
-        route = app.MapPut("customs-declarations/{mrn}/", Put)
+        app.MapPut("customs-declarations/{mrn}/", Put)
             .WithName("PutCustomsDeclaration")
             .WithTags(groupName)
             .WithSummary("Put CustomsDeclaration")
@@ -53,15 +48,6 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Write);
-
-        AllowAnonymousForDevelopment(isDevelopment, route);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
-    {
-        if (isDevelopment)
-            route.AllowAnonymous();
     }
 
     /// <param name="mrn">MRN</param>

--- a/src/Api/Endpoints/Gmrs/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/Gmrs/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Api.Extensions;
@@ -12,11 +11,11 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.Gmrs;
 
 public static class EndpointRouteBuilderExtensions
 {
-    public static void MapGmrEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    public static void MapGmrEndpoints(this IEndpointRouteBuilder app)
     {
         const string groupName = "Gmrs";
 
-        var route = app.MapGet("gmrs/{gmrId}/", Get)
+        app.MapGet("gmrs/{gmrId}/", Get)
             .WithName("GmrsByGmrId")
             .WithTags(groupName)
             .WithSummary("Get Gmr")
@@ -26,9 +25,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
 
-        AllowAnonymousForDevelopment(isDevelopment, route);
-
-        route = app.MapPut("gmrs/{gmrId}/", Put)
+        app.MapPut("gmrs/{gmrId}/", Put)
             .WithName("PutGmr")
             .WithTags(groupName)
             .WithSummary("Put Gmr")
@@ -39,15 +36,6 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Write);
-
-        AllowAnonymousForDevelopment(isDevelopment, route);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
-    {
-        if (isDevelopment)
-            route.AllowAnonymous();
     }
 
     /// <param name="gmrId">GMR ID</param>

--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Exceptions;
@@ -14,11 +13,11 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 
 public static class EndpointRouteBuilderExtensions
 {
-    public static void MapImportPreNotificationEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    public static void MapImportPreNotificationEndpoints(this IEndpointRouteBuilder app)
     {
         const string groupName = "ImportPreNotifications";
 
-        var route = app.MapGet("import-pre-notifications/{chedId}/", Get)
+        app.MapGet("import-pre-notifications/{chedId}/", Get)
             .WithName("GetImportPreNotificationByChedId")
             .WithTags(groupName)
             .WithSummary("Get ImportPreNotification")
@@ -28,9 +27,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
 
-        AllowAnonymousForDevelopment(isDevelopment, route);
-
-        route = app.MapGet("import-pre-notifications/{chedId}/customs-declarations", GetCustomsDeclarations)
+        app.MapGet("import-pre-notifications/{chedId}/customs-declarations", GetCustomsDeclarations)
             .WithName("GetCustomsDeclarationsByChedId")
             .WithTags(groupName)
             .WithSummary("Get CustomsDeclarations by CHED ID")
@@ -40,9 +37,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
 
-        AllowAnonymousForDevelopment(isDevelopment, route);
-
-        route = app.MapPut("import-pre-notifications/{chedId}/", Put)
+        app.MapPut("import-pre-notifications/{chedId}/", Put)
             .WithName("PutImportPreNotification")
             .WithTags(groupName)
             .WithSummary("Put ImportPreNotification")
@@ -54,15 +49,6 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Write);
-
-        AllowAnonymousForDevelopment(isDevelopment, route);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
-    {
-        if (isDevelopment)
-            route.AllowAnonymous();
     }
 
     /// <param name="chedId" example="CHEDA.GB.2024.1020304">CHED ID</param>

--- a/src/Api/Endpoints/ProcessingErrors/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ProcessingErrors/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Api.Extensions;
@@ -12,11 +11,11 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.ProcessingErrors;
 
 public static class EndpointRouteBuilderExtensions
 {
-    public static void MapProcessingErrorEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    public static void MapProcessingErrorEndpoints(this IEndpointRouteBuilder app)
     {
         const string groupName = "ProcessingErrors";
 
-        var route = app.MapGet("processing-errors/{mrn}/", Get)
+        app.MapGet("processing-errors/{mrn}/", Get)
             .WithName("ProcessingErrorByMrn")
             .WithTags(groupName)
             .WithSummary("Get ProcessingError")
@@ -26,9 +25,7 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
 
-        AllowAnonymousForDevelopment(isDevelopment, route);
-
-        route = app.MapPut("processing-errors/{mrn}/", Put)
+        app.MapPut("processing-errors/{mrn}/", Put)
             .WithName("PutProcessingError")
             .WithTags(groupName)
             .WithSummary("Put ProcessingError")
@@ -40,15 +37,6 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Write);
-
-        AllowAnonymousForDevelopment(isDevelopment, route);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
-    {
-        if (isDevelopment)
-            route.AllowAnonymous();
     }
 
     /// <param name="mrn">MRN</param>

--- a/src/Api/Endpoints/Search/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/Search/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
@@ -9,10 +8,11 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.Search;
 
 public static class EndpointRouteBuilderExtensions
 {
-    public static void MapSearchEndpoints(this IEndpointRouteBuilder app, bool isDevelopment)
+    public static void MapSearchEndpoints(this IEndpointRouteBuilder app)
     {
         const string groupName = "RelatedImportDeclarations";
-        var route = app.MapGet("related-import-declarations", Search)
+
+        app.MapGet("related-import-declarations", Search)
             .WithName("related-import-declarations")
             .WithTags(groupName)
             .WithSummary("related-import-declarations")
@@ -20,15 +20,6 @@ public static class EndpointRouteBuilderExtensions
             .Produces<RelatedImportDeclarationsResponse>()
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Read);
-
-        AllowAnonymousForDevelopment(isDevelopment, route);
-    }
-
-    [ExcludeFromCodeCoverage]
-    private static void AllowAnonymousForDevelopment(bool isDevelopment, RouteHandlerBuilder route)
-    {
-        if (isDevelopment)
-            route.AllowAnonymous();
     }
 
     /// <param name="request"></param>

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -149,17 +149,16 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
 static WebApplication BuildWebApplication(WebApplicationBuilder builder)
 {
     var app = builder.Build();
-    var isDevelopment = app.Environment.IsDevelopment();
 
     app.UseHeaderPropagation();
     app.UseAuthentication();
     app.UseAuthorization();
     app.MapHealth();
-    app.MapGmrEndpoints(isDevelopment);
-    app.MapImportPreNotificationEndpoints(isDevelopment);
-    app.MapCustomsDeclarationEndpoints(isDevelopment);
-    app.MapProcessingErrorEndpoints(isDevelopment);
-    app.MapSearchEndpoints(isDevelopment);
+    app.MapGmrEndpoints();
+    app.MapImportPreNotificationEndpoints();
+    app.MapCustomsDeclarationEndpoints();
+    app.MapProcessingErrorEndpoints();
+    app.MapSearchEndpoints();
     app.UseSwagger(options =>
     {
         options.RouteTemplate = "/.well-known/openapi/{documentName}/openapi.json";

--- a/tests/Api.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Api.IntegrationTests/IntegrationTestBase.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using Defra.TradeImportsDataApi.Api.Client;
 
 namespace Defra.TradeImportsDataApi.Api.IntegrationTests;
@@ -6,6 +7,15 @@ namespace Defra.TradeImportsDataApi.Api.IntegrationTests;
 [Collection("Integration Tests")]
 public abstract class IntegrationTestBase
 {
-    protected static TradeImportsDataApiClient CreateDataApiClient() =>
-        new(new HttpClient { BaseAddress = new Uri("http://localhost:8080") });
+    protected static TradeImportsDataApiClient CreateDataApiClient()
+    {
+        var httpClient = new HttpClient { BaseAddress = new Uri("http://localhost:8080") };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            // See compose.yml for username, password and scope configuration
+            Convert.ToBase64String("IntegrationTests:integration-tests-pwd"u8.ToArray())
+        );
+
+        return new TradeImportsDataApiClient(httpClient);
+    }
 }


### PR DESCRIPTION
ASPNETCORE_ENVIRONMENT previously drove auth being enabled. This was temporary and is an unclear side effect of running the service locally in Docker in DEVELOPMENT mode.

This PR therefore removes the behaviour so auth is active all the time, as it should be.