### PR TITLE
Do not include resource and change set for IPAFFS entity inserts/updates

### DIFF
--- a/src/Api/Services/DataEntityExtensions.cs
+++ b/src/Api/Services/DataEntityExtensions.cs
@@ -15,7 +15,11 @@ public static class DataEntityExtensions
         Converters = { new JsonStringEnumConverter() },
     };
 
-    public static ResourceEvent<TDataEntity> ToResourceEvent<TDataEntity>(this TDataEntity entity, string operation)
+    public static ResourceEvent<TDataEntity> ToResourceEvent<TDataEntity>(
+        this TDataEntity entity,
+        string operation,
+        bool includeEntityAsResource = true
+    )
         where TDataEntity : IDataEntity
     {
         return new ResourceEvent<TDataEntity>
@@ -24,7 +28,7 @@ public static class DataEntityExtensions
             ResourceType = ResourceTypeName<TDataEntity>(),
             Operation = operation,
             ETag = entity.ETag,
-            Resource = entity,
+            Resource = includeEntityAsResource ? entity : default,
         };
     }
 

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -2,7 +2,6 @@ using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.Events;
-using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using MongoDB.Driver.Linq;
 
 namespace Defra.TradeImportsDataApi.Api.Services;
@@ -41,9 +40,10 @@ public class ImportPreNotificationService(IDbContext dbContext, IResourceEventPu
         await dbContext.ImportPreNotifications.Insert(importPreNotificationEntity, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         await resourceEventPublisher.Publish(
-            importPreNotificationEntity
-                .ToResourceEvent(ResourceEventOperations.Created)
-                .WithChangeSet(importPreNotificationEntity.ImportPreNotification, new ImportPreNotification()),
+            importPreNotificationEntity.ToResourceEvent(
+                ResourceEventOperations.Created,
+                includeEntityAsResource: false
+            ),
             cancellationToken
         );
 
@@ -67,9 +67,10 @@ public class ImportPreNotificationService(IDbContext dbContext, IResourceEventPu
         await dbContext.ImportPreNotifications.Update(importPreNotificationEntity, etag, cancellationToken);
         await dbContext.SaveChangesAsync(cancellationToken);
         await resourceEventPublisher.Publish(
-            importPreNotificationEntity
-                .ToResourceEvent(ResourceEventOperations.Updated)
-                .WithChangeSet(importPreNotificationEntity.ImportPreNotification, existing.ImportPreNotification),
+            importPreNotificationEntity.ToResourceEvent(
+                ResourceEventOperations.Updated,
+                includeEntityAsResource: false
+            ),
             cancellationToken
         );
 

--- a/tests/Api.Tests/Services/DataEntityExtensionsTests.cs
+++ b/tests/Api.Tests/Services/DataEntityExtensionsTests.cs
@@ -1,6 +1,8 @@
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using Defra.TradeImportsDataApi.Domain.ProcessingErrors;
 using FluentAssertions;
 
 namespace Defra.TradeImportsDataApi.Api.Tests.Services;
@@ -19,6 +21,50 @@ public class DataEntityExtensionsTests
         result.Operation.Should().Be("operation");
         result.ETag.Should().Be("etag");
         result.Resource.Should().Be(subject);
+    }
+
+    [Fact]
+    public void WhenToResourceEvent_AndEntityShouldNotBeIncludedAsResource_ResourceShouldBeNull()
+    {
+        var subject = new FixtureEntity { Id = "id", ETag = "etag" };
+
+        var result = subject.ToResourceEvent("operation", includeEntityAsResource: false);
+
+        result.Resource.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenToResourceEvent_AndEntityIsImportPreNotification_ShouldMap()
+    {
+        var subject = new ImportPreNotificationEntity
+        {
+            Id = "id",
+            ImportPreNotification = new ImportPreNotification(),
+        };
+
+        var result = subject.ToResourceEvent("operation");
+
+        result.ResourceType.Should().Be("ImportPreNotification");
+    }
+
+    [Fact]
+    public void WhenToResourceEvent_AndEntityIsCustomsDeclaration_ShouldMap()
+    {
+        var subject = new CustomsDeclarationEntity { Id = "id" };
+
+        var result = subject.ToResourceEvent("operation");
+
+        result.ResourceType.Should().Be("CustomsDeclaration");
+    }
+
+    [Fact]
+    public void WhenToResourceEvent_AndEntityIsProcessingError_ShouldMap()
+    {
+        var subject = new ProcessingErrorEntity { Id = "id", ProcessingError = new ProcessingError() };
+
+        var result = subject.ToResourceEvent("operation");
+
+        result.ResourceType.Should().Be("ProcessingError");
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -31,7 +31,7 @@ public class ImportPreNotificationServiceTests
             .Received()
             .Publish(
                 Arg.Is<ResourceEvent<ImportPreNotificationEntity>>(x =>
-                    x.Operation == "Created" && x.ChangeSet.Count > 0
+                    x.Operation == "Created" && x.Resource == null && x.ChangeSet.Count == 0
                 ),
                 CancellationToken.None
             );
@@ -80,7 +80,7 @@ public class ImportPreNotificationServiceTests
             .Received()
             .Publish(
                 Arg.Is<ResourceEvent<ImportPreNotificationEntity>>(x =>
-                    x.Operation == "Updated" && x.ChangeSet.Count > 0
+                    x.Operation == "Updated" && x.Resource == null && x.ChangeSet.Count == 0
                 ),
                 CancellationToken.None
             );


### PR DESCRIPTION
The IPAFFS data is too large at times for us to emit the resource and the change set. We need to look at extended storage formats if we are to produce messages that include such data for IPAFFS.

Therefore, for now, do not include the resource and change set for import pre notification messages.