### PR TITLE
Enable indexes but do not add any Mongo DI config when running as webapplication factory integration test (as we have no Mongo instance in that context)

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -141,7 +141,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddDefaultAWSOptions(builder.Configuration.GetAWSOptions());
     builder.Services.AddAWSService<IAmazonSimpleNotificationService>();
 
-    builder.Services.AddDbContext(builder.Configuration);
+    builder.Services.AddDbContext(builder.Configuration, integrationTest);
 
     builder.Services.AddAuthenticationAuthorization();
 }

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -13,15 +13,21 @@ namespace Defra.TradeImportsDataApi.Data.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddDbContext(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddDbContext(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        bool integrationTest
+    )
     {
         services
             .AddOptions<MongoDbOptions>()
             .Bind(configuration.GetSection(MongoDbOptions.SectionName))
             .ValidateDataAnnotations();
 
-        ////services.AddHostedService<MongoIndexService>();
+        if (integrationTest)
+            return services;
 
+        services.AddHostedService<MongoIndexService>();
         services.AddScoped<IDbContext, MongoDbContext>();
         services.AddSingleton(sp =>
         {


### PR DESCRIPTION
As per PR title.

Whilst not ideal, but to be explicit, do not add the Mongo DI config when it's a web application factory integration test running as there is no Mongo instance to connect to and the tests will error.

None of the Mongo DI config is needed.

This PR also enables index creation, which is the main objective of this change.