### PR TITLE
CDMS-658: Add nullable check to the Gmr query and improve tests

### DIFF
--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -28,8 +28,15 @@ public class GmrService(IDbContext dbContext) : IGmrService
 
         return await dbContext.Gmrs.FindMany(
             x =>
-                x.Gmr.Declarations!.Customs!.Any(c => customsDeclarationIds.Any(cId => cId == c.Id))
-                || x.Gmr.Declarations!.Transits!.Any(t => customsDeclarationIds.Any(cId => cId == t.Id)),
+                x.Gmr.Declarations != null
+                && (
+                    (
+                        x.Gmr.Declarations.Customs != null
+                        && x.Gmr.Declarations.Customs.Any(c => customsDeclarationIds.Any(cId => cId == c.Id))
+                    )
+                    || x.Gmr.Declarations.Transits != null
+                        && x.Gmr.Declarations.Transits.Any(t => customsDeclarationIds.Any(cId => cId == t.Id))
+                ),
             cancellationToken
         );
     }

--- a/tests/Testing/ImportPreNotificationIdGenerator.cs
+++ b/tests/Testing/ImportPreNotificationIdGenerator.cs
@@ -4,15 +4,25 @@ namespace Defra.TradeImportsDataApi.Testing;
 
 public static class ImportPreNotificationIdGenerator
 {
-    public static string Generate()
+    private static string GenerateId()
     {
-        Random rnd = new Random();
+        var rnd = new Random();
         var sb = new StringBuilder();
-        for (int i = 0; i < 7; i++)
+        for (var i = 0; i < 7; i++)
         {
             sb.Append(rnd.Next(9));
         }
+        return sb.ToString();
+    }
 
-        return $"CHEDA.GB.2025.{sb}";
+    public static string Generate()
+    {
+        return $"CHEDA.GB.2025.{GenerateId()}";
+    }
+
+    public static (string, string) GenerateReturnId()
+    {
+        var id = GenerateId();
+        return ($"CHEDA.GB.2025.{id}", id);
     }
 }


### PR DESCRIPTION
I noticed a Mongo error around the nullability I wasn't able to reliably reproduce.  This adds in the nullability checks for safety.

The tests are also improved to create a new ID each time the test is ran.