### PR TITLE
Ensure our ImportDocumentReference domain type does not bleed into our API spec

### DIFF
--- a/src/Api/OpenApi/JsonConverterSchemaFilter.cs
+++ b/src/Api/OpenApi/JsonConverterSchemaFilter.cs
@@ -1,0 +1,19 @@
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Defra.TradeImportsDataApi.Api.OpenApi;
+
+public class JsonConverterSchemaFilter : ISchemaFilter
+{
+    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    {
+        foreach (var property in schema.Properties)
+        {
+            if (context.Type == typeof(Domain.CustomsDeclaration.ImportDocument) && property.Key == "documentReference")
+            {
+                property.Value.Type = "string";
+                property.Value.AllOf.Clear();
+            }
+        }
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -101,6 +101,7 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
         c.IncludeXmlComments(Assembly.GetExecutingAssembly());
         c.IncludeXmlComments(typeof(ImportPreNotification).Assembly);
         c.SchemaFilter<PossibleValueSchemaFilter>();
+        c.SchemaFilter<JsonConverterSchemaFilter>();
         c.CustomSchemaIds(x => x.FullName);
         c.SupportNonNullableReferenceTypes();
         c.UseAllOfToExtendReferenceSchemas();

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1346,11 +1346,7 @@
             "nullable": true
           },
           "documentReference": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Defra.TradeImportsDataApi.Domain.CustomsDeclaration.ImportDocumentReference"
-              }
-            ],
+            "type": "string",
             "nullable": true
           },
           "documentStatus": {


### PR DESCRIPTION
When the PHA API was integrating, it highlighted a type issue in our spec. As our domain type has a custom JSON converter, the underlying string value was being lost and the domain type itself was bleeding into our spec.

Therefore, catch this scenario and ensure the spec being generated is correct based on how the data would be serialised.