### PR TITLE
Add initial scaffolding for notification updates endpoint

### DIFF
--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -61,6 +61,18 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Write);
+
+        app.MapGet("import-pre-notification-updates/", GetUpdates)
+            .WithName("GetImportPreNotificationUpdates")
+            .WithTags(groupName)
+            .WithSummary("Get ImportPreNotificationUpdates")
+            .WithDescription(
+                "Get an import pre-notification updated between a period of time, which will include update checks on linked resources"
+            )
+            .Produces<ImportPreNotificationUpdatesResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
+            .RequireAuthorization(PolicyNames.Read);
     }
 
     /// <param name="chedId" example="CHEDA.GB.2024.1020304">CHED ID</param>
@@ -203,5 +215,29 @@ public static class EndpointRouteBuilderExtensions
         {
             return Results.NotFound();
         }
+    }
+
+    /// <param name="request"></param>
+    /// <param name="importPreNotificationService"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet]
+    private static async Task<IResult> GetUpdates(
+        [AsParameters] ImportPreNotificationUpdatesRequest request,
+        [FromServices] IImportPreNotificationService importPreNotificationService,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await importPreNotificationService.GetImportPreNotificationUpdates(
+            request.From,
+            request.To,
+            cancellationToken
+        );
+
+        return Results.Ok(
+            new ImportPreNotificationUpdatesResponse(
+                result.Select(x => new ImportPreNotificationUpdateResponse(x.Id, x.Updated)).ToList()
+            )
+        );
     }
 }

--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdateResponse.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdateResponse.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
+
+public record ImportPreNotificationUpdateResponse(
+    [property: JsonPropertyName("referenceNumber")] string ReferenceNumber,
+    [property: JsonPropertyName("updated")] DateTime Updated
+);

--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesRequest.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesRequest.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
+
+public class ImportPreNotificationUpdatesRequest
+{
+    [Description(
+        "Filter import pre notifications updated at this date and time or after this date and time. "
+            + " Expected value is UTC using format ISO 8601-1:2019"
+    )]
+    [FromQuery(Name = "from")]
+    public DateTime From { get; init; }
+
+    [Description(
+        "Filter import pre notifications updated before this date and time. "
+            + "Expected value is UTC using format ISO 8601-1:2019"
+    )]
+    [FromQuery(Name = "to")]
+    public DateTime To { get; init; }
+}

--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesResponse.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesResponse.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
+
+public record ImportPreNotificationUpdatesResponse(
+    [property: JsonPropertyName("importPreNotificationUpdates")]
+        IReadOnlyList<ImportPreNotificationUpdateResponse> ImportPreNotificationUpdates
+);

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -64,6 +64,11 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
 
     // This adds default rate limiter, total request timeout, retries, circuit breaker and timeout per attempt
     builder.Services.ConfigureHttpClientDefaults(options => options.AddStandardResilienceHandler());
+    builder.Services.Configure<RouteHandlerOptions>(o =>
+    {
+        // Without this, bad request detail will only be thrown in DEVELOPMENT mode
+        o.ThrowOnBadRequest = true;
+    });
     builder.Services.AddProblemDetails();
     builder.Services.AddHealth();
     builder.Services.AddEndpointsApiExplorer();

--- a/src/Api/Services/IImportPreNotificationService.cs
+++ b/src/Api/Services/IImportPreNotificationService.cs
@@ -10,13 +10,21 @@ public interface IImportPreNotificationService
         string mrn,
         CancellationToken cancellationToken
     );
+
     Task<ImportPreNotificationEntity> Insert(
         ImportPreNotificationEntity importPreNotificationEntity,
         CancellationToken cancellationToken
     );
+
     Task<ImportPreNotificationEntity> Update(
         ImportPreNotificationEntity importPreNotificationEntity,
         string etag,
+        CancellationToken cancellationToken
+    );
+
+    Task<List<ImportPreNotificationEntity>> GetImportPreNotificationUpdates(
+        DateTime from,
+        DateTime to,
         CancellationToken cancellationToken
     );
 }

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -2,6 +2,7 @@ using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.Events;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using MongoDB.Driver.Linq;
 
 namespace Defra.TradeImportsDataApi.Api.Services;
@@ -75,5 +76,24 @@ public class ImportPreNotificationService(IDbContext dbContext, IResourceEventPu
         );
 
         return importPreNotificationEntity;
+    }
+
+    public Task<List<ImportPreNotificationEntity>> GetImportPreNotificationUpdates(
+        DateTime from,
+        DateTime to,
+        CancellationToken cancellationToken
+    )
+    {
+        return Task.FromResult(
+            new List<ImportPreNotificationEntity>
+            {
+                new()
+                {
+                    Id = "CHEDPP.GB.2024.5194492",
+                    ImportPreNotification = new ImportPreNotification { ReferenceNumber = "CHEDPP.GB.2024.5194492" },
+                    Updated = new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc),
+                },
+            }
+        );
     }
 }

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: Bad Request,
+  status: 400,
+  detail: Required parameter "DateTime From" was not provided from query string.,
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
@@ -1,0 +1,8 @@
+﻿{
+  importPreNotificationUpdates: [
+    {
+      referenceNumber: CHEDPP.GB.2024.5194492,
+      updated: 2025-05-21T08:51:00Z
+    }
+  ]
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Defra.TradeImportsDataApi.Api.Services;
+using Defra.TradeImportsDataApi.Api.Tests.Utils.InMemoryData;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using WireMock.Server;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Endpoints.ImportPreNotifications;
+
+public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
+{
+    private WireMockServer WireMock { get; }
+    private readonly VerifySettings _settings;
+
+    public GetUpdatesTests(ApiWebApplicationFactory factory, ITestOutputHelper outputHelper, WireMockContext context)
+        : base(factory, outputHelper)
+    {
+        WireMock = context.Server;
+        WireMock.Reset();
+
+        _settings = new VerifySettings();
+        _settings.ScrubMember("traceId");
+        _settings.DontScrubDateTimes();
+        _settings.DontScrubGuids();
+        _settings.DontIgnoreEmptyCollections();
+    }
+
+    protected override void ConfigureTestServices(IServiceCollection services)
+    {
+        base.ConfigureTestServices(services);
+
+        services.AddTransient<IDbContext>(_ => new MemoryDbContext());
+        services.AddTransient<IResourceEventPublisher>(_ => Substitute.For<IResourceEventPublisher>());
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates());
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenValidRequest_ShouldReturnSingle()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 21, 10, 30, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 21, 10, 40, 0, DateTimeKind.Utc)))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenUnauthorized_ShouldBeUnauthorized()
+    {
+        var client = CreateClient(addDefaultAuthorizationHeader: false);
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_WhenWriteOnly_ShouldBeForbidden()
+    {
+        var client = CreateClient(testUser: TestUser.WriteOnly);
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -622,6 +622,72 @@
         }
       }
     },
+    "/import-pre-notification-updates": {
+      "get": {
+        "tags": [
+          "ImportPreNotifications"
+        ],
+        "summary": "Get ImportPreNotificationUpdates",
+        "description": "Get an import pre-notification updated between a period of time, which will include update checks on linked resources",
+        "operationId": "GetImportPreNotificationUpdates",
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Filter import pre notifications updated at this date and time or after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter import pre notifications updated at this date and time or after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "Filter import pre notifications updated before this date and time. Expected value is UTC using format ISO 8601-1:2019",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter import pre notifications updated before this date and time. Expected value is UTC using format ISO 8601-1:2019",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Defra.TradeImportsDataApi.ImportPreNotificationUpdatesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/processing-errors/{mrn}": {
       "get": {
         "tags": [
@@ -3486,6 +3552,31 @@
           "updated": {
             "type": "string",
             "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.ImportPreNotificationUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "referenceNumber": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.ImportPreNotificationUpdatesResponse": {
+        "type": "object",
+        "properties": {
+          "importPreNotificationUpdates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.ImportPreNotificationUpdateResponse"
+            }
           }
         },
         "additionalProperties": false

--- a/tests/Testing/EndpointFilter.cs
+++ b/tests/Testing/EndpointFilter.cs
@@ -1,0 +1,12 @@
+namespace Defra.TradeImportsDataApi.Testing;
+
+public class EndpointFilter
+{
+    internal string Filter { get; }
+
+    private EndpointFilter(string filter) => Filter = filter;
+
+    public static EndpointFilter From(DateTime from) => new($"from={from:O}");
+
+    public static EndpointFilter To(DateTime to) => new($"to={to:O}");
+}

--- a/tests/Testing/EndpointQuery.cs
+++ b/tests/Testing/EndpointQuery.cs
@@ -1,0 +1,17 @@
+namespace Defra.TradeImportsDataApi.Testing;
+
+public class EndpointQuery
+{
+    private readonly EndpointFilter[] _filters = [];
+
+    public EndpointQuery() { }
+
+    public static EndpointQuery New => new();
+
+    private EndpointQuery(EndpointFilter[] filters) => _filters = filters;
+
+    public EndpointQuery Where(EndpointFilter filter) => new([.. _filters, filter]);
+
+    public override string ToString() =>
+        _filters.Length == 0 ? string.Empty : "?" + string.Join("&", _filters.Select(f => f.Filter));
+}

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -29,6 +29,8 @@ public static class Endpoints
         public static string GetGmrs(string chedId) => $"{Root}/{chedId}/gmrs";
 
         public static string Put(string chedId) => $"{Root}/{chedId}";
+
+        public static string GetUpdates(EndpointQuery? query = null) => $"/import-pre-notification-updates{query}";
     }
 
     public static class CustomsDeclarations


### PR DESCRIPTION
As the endpoint will only be notification reference number and an updated date, I decided to create a path away from the existing notifications one.

Consumers will call `/import-pre-notification-updates` with a from and to date as query params (for now).

Only dummy data is returned currently, in order to get approval on the endpoint structure.