### PR TITLE
Add filtering of notifications by from and to value against .Updated field

### DIFF
--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -236,7 +236,7 @@ public static class EndpointRouteBuilderExtensions
 
         return Results.Ok(
             new ImportPreNotificationUpdatesResponse(
-                result.Select(x => new ImportPreNotificationUpdateResponse(x.Id, x.Updated)).ToList()
+                result.Select(x => new ImportPreNotificationUpdateResponse(x.ReferenceNumber, x.Updated)).ToList()
             )
         );
     }

--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -27,16 +27,7 @@ public class GmrService(IDbContext dbContext) : IGmrService
             return [];
 
         return await dbContext.Gmrs.FindMany(
-            x =>
-                x.Gmr.Declarations != null
-                && (
-                    (
-                        x.Gmr.Declarations.Customs != null
-                        && x.Gmr.Declarations.Customs.Any(c => customsDeclarationIds.Any(cId => cId == c.Id))
-                    )
-                    || x.Gmr.Declarations.Transits != null
-                        && x.Gmr.Declarations.Transits.Any(t => customsDeclarationIds.Any(cId => cId == t.Id))
-                ),
+            x => x.CustomsDeclarationIdentifiers.Any(id => customsDeclarationIds.Any(cId => cId == id)),
             cancellationToken
         );
     }

--- a/src/Api/Services/IImportPreNotificationService.cs
+++ b/src/Api/Services/IImportPreNotificationService.cs
@@ -22,7 +22,7 @@ public interface IImportPreNotificationService
         CancellationToken cancellationToken
     );
 
-    Task<List<ImportPreNotificationEntity>> GetImportPreNotificationUpdates(
+    Task<List<ImportPreNotificationUpdate>> GetImportPreNotificationUpdates(
         DateTime from,
         DateTime to,
         CancellationToken cancellationToken

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -78,21 +78,16 @@ public class ImportPreNotificationService(IDbContext dbContext, IResourceEventPu
         return importPreNotificationEntity;
     }
 
-    public Task<List<ImportPreNotificationEntity>> GetImportPreNotificationUpdates(
+    public Task<List<ImportPreNotificationUpdate>> GetImportPreNotificationUpdates(
         DateTime from,
         DateTime to,
         CancellationToken cancellationToken
     )
     {
         return Task.FromResult(
-            new List<ImportPreNotificationEntity>
+            new List<ImportPreNotificationUpdate>
             {
-                new()
-                {
-                    Id = "CHEDPP.GB.2024.5194492",
-                    ImportPreNotification = new ImportPreNotification { ReferenceNumber = "CHEDPP.GB.2024.5194492" },
-                    Updated = new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc),
-                },
+                new("CHEDPP.GB.2024.5194492", new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc)),
             }
         );
     }

--- a/src/Api/Services/ImportPreNotificationUpdate.cs
+++ b/src/Api/Services/ImportPreNotificationUpdate.cs
@@ -1,0 +1,3 @@
+namespace Defra.TradeImportsDataApi.Api.Services;
+
+public record ImportPreNotificationUpdate(string ReferenceNumber, DateTime Updated);

--- a/src/Data/Entities/GmrEntity.cs
+++ b/src/Data/Entities/GmrEntity.cs
@@ -6,6 +6,8 @@ public class GmrEntity : IDataEntity
 {
     public required string Id { get; set; }
 
+    public List<string> CustomsDeclarationIdentifiers { get; set; } = [];
+
     public string ETag { get; set; } = null!;
 
     public DateTime Created { get; set; }
@@ -14,5 +16,13 @@ public class GmrEntity : IDataEntity
 
     public required Gmr Gmr { get; set; }
 
-    public void OnSave() { }
+    public void OnSave()
+    {
+        CustomsDeclarationIdentifiers.Clear();
+
+        var customs = Gmr.Declarations?.Customs?.Select(x => x.Id) ?? [];
+        var transits = Gmr.Declarations?.Transits?.Select(x => x.Id) ?? [];
+
+        CustomsDeclarationIdentifiers.AddRange(customs.Concat(transits).Where(x => !string.IsNullOrWhiteSpace(x))!);
+    }
 }

--- a/src/Data/Mongo/MongoIndexService.cs
+++ b/src/Data/Mongo/MongoIndexService.cs
@@ -11,21 +11,54 @@ public class MongoIndexService(IMongoDatabase database, ILogger<MongoIndexServic
 {
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        await CreateImportPreNotificationIndexes(cancellationToken);
+        await CreateCustomsDeclarationIndexes(cancellationToken);
+        await CreateGmrIndexes(cancellationToken);
+    }
+
+    private async Task CreateGmrIndexes(CancellationToken cancellationToken)
+    {
         await CreateIndex(
-            "CustomDeclarationIdentifierIdx",
-            Builders<ImportPreNotificationEntity>.IndexKeys.Ascending(n => n.CustomsDeclarationIdentifier),
+            "CustomsDeclarationIdentifierIdx",
+            Builders<GmrEntity>.IndexKeys.Ascending(x => x.CustomsDeclarationIdentifiers),
             cancellationToken: cancellationToken
         );
+        await CreateIndex(
+            "UpdatedIdx",
+            Builders<GmrEntity>.IndexKeys.Ascending(x => x.Updated),
+            cancellationToken: cancellationToken
+        );
+    }
 
+    private async Task CreateCustomsDeclarationIndexes(CancellationToken cancellationToken)
+    {
         await CreateIndex(
             "ImportPreNotificationIdentifierIdx",
-            Builders<CustomsDeclarationEntity>.IndexKeys.Ascending(n => n.ImportPreNotificationIdentifiers),
+            Builders<CustomsDeclarationEntity>.IndexKeys.Ascending(x => x.ImportPreNotificationIdentifiers),
             cancellationToken: cancellationToken
         );
-
         await CreateIndex(
             "DeclarationUcrIdx",
-            Builders<CustomsDeclarationEntity>.IndexKeys.Ascending(n => n.ClearanceRequest!.DeclarationUcr),
+            Builders<CustomsDeclarationEntity>.IndexKeys.Ascending(x => x.ClearanceRequest!.DeclarationUcr),
+            cancellationToken: cancellationToken
+        );
+        await CreateIndex(
+            "UpdatedIdx",
+            Builders<CustomsDeclarationEntity>.IndexKeys.Ascending(x => x.Updated),
+            cancellationToken: cancellationToken
+        );
+    }
+
+    private async Task CreateImportPreNotificationIndexes(CancellationToken cancellationToken)
+    {
+        await CreateIndex(
+            "CustomDeclarationIdentifierIdx",
+            Builders<ImportPreNotificationEntity>.IndexKeys.Ascending(x => x.CustomsDeclarationIdentifier),
+            cancellationToken: cancellationToken
+        );
+        await CreateIndex(
+            "UpdatedIdx",
+            Builders<ImportPreNotificationEntity>.IndexKeys.Ascending(x => x.Updated),
             cancellationToken: cancellationToken
         );
     }

--- a/tests/Api.IntegrationTests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.IntegrationTests/Services/ImportPreNotificationServiceTests.cs
@@ -1,0 +1,98 @@
+using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsDataApi.Api.Services;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Data.Mongo;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+using MongoDB.Driver;
+using NSubstitute;
+
+namespace Defra.TradeImportsDataApi.Api.IntegrationTests.Services;
+
+public class ImportPreNotificationServiceTests : IntegrationTestBase, IAsyncLifetime
+{
+    public required IMongoCollection<ImportPreNotificationEntity> Notifications { get; set; }
+    public required IMongoCollection<GmrEntity> Gmrs { get; set; }
+    public required IMongoCollection<CustomsDeclarationEntity> CustomsDeclarations { get; set; }
+    public required TradeImportsDataApiClient Client { get; set; }
+    public required MongoDbContext MongoDbContext { get; set; }
+    public required ImportPreNotificationService Subject { get; set; }
+
+    private static DateTime Updated => new(2025, 5, 20, 16, 0, 0, DateTimeKind.Utc);
+
+    public async Task InitializeAsync()
+    {
+        Notifications = GetMongoCollection<ImportPreNotificationEntity>();
+        Gmrs = GetMongoCollection<GmrEntity>();
+        CustomsDeclarations = GetMongoCollection<CustomsDeclarationEntity>();
+
+        await Notifications.DeleteManyAsync(FilterDefinition<ImportPreNotificationEntity>.Empty);
+        await Gmrs.DeleteManyAsync(FilterDefinition<GmrEntity>.Empty);
+        await CustomsDeclarations.DeleteManyAsync(FilterDefinition<CustomsDeclarationEntity>.Empty);
+
+        Client = CreateDataApiClient();
+        MongoDbContext = new MongoDbContext(GetMongoDatabase());
+        Subject = new ImportPreNotificationService(MongoDbContext, Substitute.For<IResourceEventPublisher>());
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Theory]
+    [InlineData(-1, 1, true)]
+    [InlineData(0, 1, true)]
+    [InlineData(-1, -1, false)]
+    public async Task WhenImportPreNotificationUpdated_ThenNotificationIdAndUpdateAsExpected(
+        int fromSeconds,
+        int toSeconds,
+        bool expectResult
+    )
+    {
+        var (chedRef, _) = ImportPreNotificationIdGenerator.GenerateReturnId();
+
+        // Set up CHED where the CHED has been updated within the query period
+        await CreateNotification(chedRef);
+        await OverrideUpdated(Notifications, chedRef, Updated);
+
+        var result = await Subject.GetImportPreNotificationUpdates(
+            Updated.AddSeconds(fromSeconds),
+            Updated.AddSeconds(toSeconds),
+            CancellationToken.None
+        );
+
+        AssertResult(expectResult, result, chedRef);
+    }
+
+    private static void AssertResult(bool expectResult, List<ImportPreNotificationUpdate> result, string chedRef)
+    {
+        if (expectResult)
+        {
+            result.Should().HaveCount(1);
+            result[0].ReferenceNumber.Should().Be(chedRef);
+            result[0].Updated.Should().Be(Updated);
+        }
+        else
+        {
+            result.Should().BeEmpty();
+        }
+    }
+
+    private async Task CreateNotification(string chedRef)
+    {
+        await Client.PutImportPreNotification(
+            chedRef,
+            new ImportPreNotification { ReferenceNumber = chedRef, Version = 1 },
+            null,
+            CancellationToken.None
+        );
+    }
+
+    private static async Task OverrideUpdated<T>(IMongoCollection<T> collection, string id, DateTime updated)
+        where T : IDataEntity
+    {
+        var filter = Builders<T>.Filter.Eq(x => x.Id, id);
+        var update = Builders<T>.Update.Set(x => x.Updated, updated);
+
+        await collection.UpdateOneAsync(filter, update);
+    }
+}


### PR DESCRIPTION
Query for notifications translates to:

```
db.getCollection("ImportPreNotificationEntity").aggregate(
    [
        {
            "$match" : {
                "updated" : {
                    "$gte" : ISODate("2025-05-20T15:59:59.000+0000"),
                    "$lt" : ISODate("2025-05-20T16:00:01.000+0000")
                }
            }
        }, 
        {
            "$project" : {
                "referenceNumber" : "$_id",
                "updated" : "$updated",
                "_id" : 0.0
            }
        }
    ]
);
```

This uses the index on the Updated field of the notification.

This is part one of bringing in changes from original work in PR https://github.com/DEFRA/trade-imports-data-api/pull/117 that was reverted.