### PR TITLE
Introduce repository layer so we can encapsulate data reading/writing

### DIFF
--- a/src/Api/Data/CustomsDeclarationRepository.cs
+++ b/src/Api/Data/CustomsDeclarationRepository.cs
@@ -1,0 +1,79 @@
+using System.Linq.Expressions;
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Data.Extensions;
+using MongoDB.Driver.Linq;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclarationRepository
+{
+    public async Task<CustomsDeclarationEntity?> Get(string id, CancellationToken cancellationToken) =>
+        await dbContext.CustomsDeclarations.Find(id, cancellationToken);
+
+    public async Task<List<CustomsDeclarationEntity>> GetAll(
+        string importPreNotificationIdentifier,
+        CancellationToken cancellationToken
+    ) =>
+        await dbContext
+            .CustomsDeclarations.Where(x =>
+                x.ImportPreNotificationIdentifiers.Contains(importPreNotificationIdentifier)
+            )
+            .ToListWithFallbackAsync(cancellationToken);
+
+    public async Task<List<CustomsDeclarationEntity>> GetAll(
+        Expression<Func<CustomsDeclarationEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    ) => await dbContext.CustomsDeclarations.Where(predicate).ToListWithFallbackAsync(cancellationToken);
+
+    public async Task<List<string>> GetAllIds(
+        string importPreNotificationIdentifier,
+        CancellationToken cancellationToken
+    ) =>
+        await dbContext
+            .CustomsDeclarations.Where(x =>
+                x.ImportPreNotificationIdentifiers.Contains(importPreNotificationIdentifier)
+            )
+            .Select(x => x.Id)
+            .Distinct()
+            .ToListWithFallbackAsync(cancellationToken);
+
+    public async Task<List<string>> GetAllImportPreNotificationIdentifiers(
+        string id,
+        CancellationToken cancellationToken
+    ) =>
+        await dbContext
+            .CustomsDeclarations.Where(x => x.Id == id)
+            .SelectMany(x => x.ImportPreNotificationIdentifiers)
+            .ToListAsync(cancellationToken);
+
+    public async Task<CustomsDeclarationEntity> Insert(
+        CustomsDeclarationEntity entity,
+        CancellationToken cancellationToken
+    )
+    {
+        await dbContext.CustomsDeclarations.Insert(entity, cancellationToken);
+
+        return entity;
+    }
+
+    public async Task<(CustomsDeclarationEntity Existing, CustomsDeclarationEntity Updated)> Update(
+        CustomsDeclarationEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    )
+    {
+        var existing = await Get(entity.Id, cancellationToken);
+        if (existing == null)
+        {
+            throw new EntityNotFoundException(nameof(CustomsDeclarationEntity), entity.Id);
+        }
+
+        entity.Created = existing.Created;
+
+        await dbContext.CustomsDeclarations.Update(entity, etag, cancellationToken);
+
+        return (existing, entity);
+    }
+}

--- a/src/Api/Data/GmrRepository.cs
+++ b/src/Api/Data/GmrRepository.cs
@@ -1,0 +1,43 @@
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public class GmrRepository(IDbContext dbContext) : IGmrRepository
+{
+    public Task<GmrEntity?> Get(string id, CancellationToken cancellationToken) =>
+        dbContext.Gmrs.Find(id, cancellationToken);
+
+    public async Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken) =>
+        await dbContext.Gmrs.FindMany(
+            x => x.CustomsDeclarationIdentifiers.Any(id => customsDeclarationIds.Any(cId => cId == id)),
+            cancellationToken
+        );
+
+    public async Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken)
+    {
+        await dbContext.Gmrs.Insert(entity, cancellationToken);
+
+        return entity;
+    }
+
+    public async Task<(GmrEntity Existing, GmrEntity Updated)> Update(
+        GmrEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    )
+    {
+        var existing = await dbContext.Gmrs.Find(entity.Id, cancellationToken);
+        if (existing == null)
+        {
+            throw new EntityNotFoundException(nameof(GmrEntity), entity.Id);
+        }
+
+        entity.Created = existing.Created;
+
+        await dbContext.Gmrs.Update(entity, etag, cancellationToken);
+
+        return (existing, entity);
+    }
+}

--- a/src/Api/Data/ICustomsDeclarationRepository.cs
+++ b/src/Api/Data/ICustomsDeclarationRepository.cs
@@ -1,0 +1,31 @@
+using System.Linq.Expressions;
+using Defra.TradeImportsDataApi.Data.Entities;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public interface ICustomsDeclarationRepository
+{
+    Task<CustomsDeclarationEntity?> Get(string id, CancellationToken cancellationToken);
+
+    Task<List<CustomsDeclarationEntity>> GetAll(
+        string importPreNotificationIdentifier,
+        CancellationToken cancellationToken
+    );
+
+    Task<List<CustomsDeclarationEntity>> GetAll(
+        Expression<Func<CustomsDeclarationEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    );
+
+    Task<List<string>> GetAllIds(string importPreNotificationIdentifier, CancellationToken cancellationToken);
+
+    Task<List<string>> GetAllImportPreNotificationIdentifiers(string id, CancellationToken cancellationToken);
+
+    Task<CustomsDeclarationEntity> Insert(CustomsDeclarationEntity entity, CancellationToken cancellationToken);
+
+    Task<(CustomsDeclarationEntity Existing, CustomsDeclarationEntity Updated)> Update(
+        CustomsDeclarationEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Api/Data/IGmrRepository.cs
+++ b/src/Api/Data/IGmrRepository.cs
@@ -1,0 +1,18 @@
+using Defra.TradeImportsDataApi.Data.Entities;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public interface IGmrRepository
+{
+    Task<GmrEntity?> Get(string id, CancellationToken cancellationToken);
+
+    Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken);
+
+    Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken);
+
+    Task<(GmrEntity Existing, GmrEntity Updated)> Update(
+        GmrEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Api/Data/IImportPreNotificationRepository.cs
+++ b/src/Api/Data/IImportPreNotificationRepository.cs
@@ -1,0 +1,43 @@
+using System.Linq.Expressions;
+using Defra.TradeImportsDataApi.Data.Entities;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public interface IImportPreNotificationRepository
+{
+    Task<ImportPreNotificationEntity?> Get(string id, CancellationToken cancellationToken);
+
+    Task<ImportPreNotificationEntity?> GetByCustomsDeclarationIdentifier(
+        string customsDeclarationIdentifier,
+        CancellationToken cancellationToken
+    );
+
+    Task<List<ImportPreNotificationEntity>> GetAll(
+        string[] customsDeclarationIdentifiers,
+        CancellationToken cancellationToken
+    );
+
+    Task<List<ImportPreNotificationEntity>> GetAll(
+        Expression<Func<ImportPreNotificationEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    );
+
+    Task<string?> GetCustomsDeclarationIdentifier(string id, CancellationToken cancellationToken);
+
+    Task<List<ImportPreNotificationUpdate>> GetUpdates(
+        DateTime from,
+        DateTime to,
+        string[]? pointOfEntry = null,
+        string[]? type = null,
+        string[]? status = null,
+        CancellationToken cancellationToken = default
+    );
+
+    Task<ImportPreNotificationEntity> Insert(ImportPreNotificationEntity entity, CancellationToken cancellationToken);
+
+    Task<(ImportPreNotificationEntity Existing, ImportPreNotificationEntity Updated)> Update(
+        ImportPreNotificationEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Api/Data/IProcessingErrorRepository.cs
+++ b/src/Api/Data/IProcessingErrorRepository.cs
@@ -1,0 +1,16 @@
+using Defra.TradeImportsDataApi.Data.Entities;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public interface IProcessingErrorRepository
+{
+    Task<ProcessingErrorEntity?> Get(string id, CancellationToken cancellationToken);
+
+    Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken);
+
+    Task<(ProcessingErrorEntity Existing, ProcessingErrorEntity Updated)> Update(
+        ProcessingErrorEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/Api/Data/ImportPreNotificationRepository.cs
+++ b/src/Api/Data/ImportPreNotificationRepository.cs
@@ -1,0 +1,143 @@
+using System.Linq.Expressions;
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Data.Extensions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using MongoDB.Driver.Linq;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public class ImportPreNotificationRepository(IDbContext dbContext, ILogger<ImportPreNotificationRepository> logger)
+    : IImportPreNotificationRepository
+{
+    public async Task<ImportPreNotificationEntity?> Get(string id, CancellationToken cancellationToken) =>
+        await dbContext.ImportPreNotifications.Find(id, cancellationToken);
+
+    public async Task<ImportPreNotificationEntity?> GetByCustomsDeclarationIdentifier(
+        string customsDeclarationIdentifier,
+        CancellationToken cancellationToken
+    ) =>
+        (
+            await dbContext
+                .ImportPreNotifications.Where(x => x.CustomsDeclarationIdentifier == customsDeclarationIdentifier)
+                .ToListWithFallbackAsync(cancellationToken)
+        ).SingleOrDefault();
+
+    public async Task<List<ImportPreNotificationEntity>> GetAll(
+        string[] customsDeclarationIdentifiers,
+        CancellationToken cancellationToken
+    ) =>
+        await dbContext
+            .ImportPreNotifications.Where(x => customsDeclarationIdentifiers.Contains(x.CustomsDeclarationIdentifier))
+            .ToListWithFallbackAsync(cancellationToken);
+
+    public async Task<List<ImportPreNotificationEntity>> GetAll(
+        Expression<Func<ImportPreNotificationEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    ) => await dbContext.ImportPreNotifications.Where(predicate).ToListWithFallbackAsync(cancellationToken);
+
+    public async Task<string?> GetCustomsDeclarationIdentifier(string id, CancellationToken cancellationToken) =>
+        await dbContext
+            .ImportPreNotifications.Where(x => x.Id == id)
+            .Select(x => x.CustomsDeclarationIdentifier)
+            .FirstOrDefaultAsync(cancellationToken);
+
+    public async Task<List<ImportPreNotificationUpdate>> GetUpdates(
+        DateTime from,
+        DateTime to,
+        string[]? pointOfEntry = null,
+        string[]? type = null,
+        string[]? status = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        // See UpdatesIdx index and field order - query order matches the index field order
+        // _id included in index as final projection produces an update object, which means
+        // only the index is needed to provide the result from this query.
+
+        var where = new BsonDocument
+        {
+            {
+                "updated",
+                new BsonDocument { { "$gte", from }, { "$lt", to } }
+            },
+        };
+
+        if (pointOfEntry is { Length: > 0 })
+            where.Add(
+                "importPreNotification.partOne.pointOfEntry",
+                new BsonDocument { { "$in", new BsonArray(pointOfEntry) } }
+            );
+
+        if (type is { Length: > 0 })
+            where.Add(
+                "importPreNotification.importNotificationType",
+                new BsonDocument { { "$in", new BsonArray(type) } }
+            );
+
+        if (status is { Length: > 0 })
+            where.Add("importPreNotification.status", new BsonDocument { { "$in", new BsonArray(status) } });
+
+        var pipeline = new[]
+        {
+            new BsonDocument("$match", where),
+            new BsonDocument(
+                "$project",
+                new BsonDocument
+                {
+                    // _id is always returned
+                    { "updated", "$updated" },
+                }
+            ),
+        };
+
+        var start = TimeProvider.System.GetTimestamp();
+        var query = string.Join(",\n", pipeline.Select(x => x.ToString()));
+
+        var aggregate = await dbContext.ImportPreNotifications.Collection.AggregateAsync<NotificationUpdate>(
+            pipeline,
+            cancellationToken: cancellationToken
+        );
+
+        var updates = (await aggregate.ToListAsync(cancellationToken)).ToDictionary(x => x.Id, x => x);
+
+        var elapsed = TimeProvider.System.GetElapsedTime(start);
+        logger.LogInformation("Updates (notifications): {Elapsed} {Query}", elapsed.TotalMilliseconds, query);
+
+        return updates.Values.Select(x => new ImportPreNotificationUpdate(x.Id, x.Updated)).ToList();
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private sealed record NotificationUpdate(string Id, DateTime Updated);
+
+    public async Task<ImportPreNotificationEntity> Insert(
+        ImportPreNotificationEntity entity,
+        CancellationToken cancellationToken
+    )
+    {
+        await dbContext.ImportPreNotifications.Insert(entity, cancellationToken);
+
+        return entity;
+    }
+
+    public async Task<(ImportPreNotificationEntity Existing, ImportPreNotificationEntity Updated)> Update(
+        ImportPreNotificationEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    )
+    {
+        var existing = await dbContext.ImportPreNotifications.Find(entity.Id, cancellationToken);
+        if (existing == null)
+        {
+            throw new EntityNotFoundException(nameof(ImportPreNotificationEntity), entity.Id);
+        }
+
+        entity.Created = existing.Created;
+
+        await dbContext.ImportPreNotifications.Update(entity, etag, cancellationToken);
+
+        return (existing, entity);
+    }
+}

--- a/src/Api/Data/ImportPreNotificationUpdate.cs
+++ b/src/Api/Data/ImportPreNotificationUpdate.cs
@@ -1,3 +1,3 @@
-namespace Defra.TradeImportsDataApi.Api.Services;
+namespace Defra.TradeImportsDataApi.Api.Data;
 
 public record ImportPreNotificationUpdate(string ReferenceNumber, DateTime Updated);

--- a/src/Api/Data/ProcessingErrorRepository.cs
+++ b/src/Api/Data/ProcessingErrorRepository.cs
@@ -1,0 +1,37 @@
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public class ProcessingErrorRepository(IDbContext dbContext) : IProcessingErrorRepository
+{
+    public async Task<ProcessingErrorEntity?> Get(string id, CancellationToken cancellationToken) =>
+        await dbContext.ProcessingErrors.Find(id, cancellationToken);
+
+    public async Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken)
+    {
+        await dbContext.ProcessingErrors.Insert(entity, cancellationToken);
+
+        return entity;
+    }
+
+    public async Task<(ProcessingErrorEntity Existing, ProcessingErrorEntity Updated)> Update(
+        ProcessingErrorEntity entity,
+        string etag,
+        CancellationToken cancellationToken
+    )
+    {
+        var existing = await dbContext.ProcessingErrors.Find(entity.Id, cancellationToken);
+        if (existing == null)
+        {
+            throw new EntityNotFoundException(nameof(ProcessingErrorEntity), entity.Id);
+        }
+
+        entity.Created = existing.Created;
+
+        await dbContext.ProcessingErrors.Update(entity, etag, cancellationToken);
+
+        return (existing, entity);
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Amazon.SimpleNotificationService;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Configuration;
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.Gmrs;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
@@ -172,6 +173,10 @@ static void ConfigureWebApplication(WebApplicationBuilder builder, string[] args
     builder.Services.AddAWSService<IAmazonSimpleNotificationService>();
 
     builder.Services.AddDbContext(builder.Configuration, integrationTest);
+    builder.Services.AddTransient<IImportPreNotificationRepository, ImportPreNotificationRepository>();
+    builder.Services.AddTransient<ICustomsDeclarationRepository, CustomsDeclarationRepository>();
+    builder.Services.AddTransient<IGmrRepository, GmrRepository>();
+    builder.Services.AddTransient<IProcessingErrorRepository, ProcessingErrorRepository>();
 
     builder.Services.AddAuthenticationAuthorization();
 }

--- a/src/Api/Services/ICustomsDeclarationService.cs
+++ b/src/Api/Services/ICustomsDeclarationService.cs
@@ -4,16 +4,18 @@ namespace Defra.TradeImportsDataApi.Api.Services;
 
 public interface ICustomsDeclarationService
 {
-    Task<CustomsDeclarationEntity?> GetCustomsDeclaration(string mrn, CancellationToken cancellationToken);
+    Task<CustomsDeclarationEntity?> GetCustomsDeclaration(string id, CancellationToken cancellationToken);
 
     Task<List<CustomsDeclarationEntity>> GetCustomsDeclarationsByChedId(
         string chedId,
         CancellationToken cancellationToken
     );
+
     Task<CustomsDeclarationEntity> Insert(
         CustomsDeclarationEntity customsDeclarationEntity,
         CancellationToken cancellationToken
     );
+
     Task<CustomsDeclarationEntity> Update(
         CustomsDeclarationEntity customsDeclarationEntity,
         string etag,

--- a/src/Api/Services/IGmrService.cs
+++ b/src/Api/Services/IGmrService.cs
@@ -4,8 +4,11 @@ namespace Defra.TradeImportsDataApi.Api.Services;
 
 public interface IGmrService
 {
-    Task<GmrEntity?> GetGmr(string gmrId, CancellationToken cancellationToken);
+    Task<GmrEntity?> GetGmr(string id, CancellationToken cancellationToken);
+
     Task<List<GmrEntity>> GetGmrByChedId(string chedId, CancellationToken cancellationToken);
+
     Task<GmrEntity> Insert(GmrEntity gmrEntity, CancellationToken cancellationToken);
+
     Task<GmrEntity> Update(GmrEntity gmrEntity, string etag, CancellationToken cancellationToken);
 }

--- a/src/Api/Services/IImportPreNotificationService.cs
+++ b/src/Api/Services/IImportPreNotificationService.cs
@@ -1,3 +1,4 @@
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 
 namespace Defra.TradeImportsDataApi.Api.Services;

--- a/src/Api/Services/ProcessingErrorService.cs
+++ b/src/Api/Services/ProcessingErrorService.cs
@@ -1,3 +1,4 @@
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
@@ -6,29 +7,32 @@ using Defra.TradeImportsDataApi.Domain.ProcessingErrors;
 
 namespace Defra.TradeImportsDataApi.Api.Services;
 
-public class ProcessingErrorService(IDbContext dbContext, IResourceEventPublisher resourceEventPublisher)
-    : IProcessingErrorService
+public class ProcessingErrorService(
+    IDbContext dbContext,
+    IResourceEventPublisher resourceEventPublisher,
+    IProcessingErrorRepository processingErrorRepository
+) : IProcessingErrorService
 {
-    public async Task<ProcessingErrorEntity?> GetProcessingError(string mrn, CancellationToken cancellationToken)
-    {
-        return await dbContext.ProcessingErrors.Find(mrn, cancellationToken);
-    }
+    public async Task<ProcessingErrorEntity?> GetProcessingError(string mrn, CancellationToken cancellationToken) =>
+        await processingErrorRepository.Get(mrn, cancellationToken);
 
     public async Task<ProcessingErrorEntity> Insert(
         ProcessingErrorEntity processingErrorEntity,
         CancellationToken cancellationToken
     )
     {
-        await dbContext.ProcessingErrors.Insert(processingErrorEntity, cancellationToken);
+        var inserted = await processingErrorRepository.Insert(processingErrorEntity, cancellationToken);
+
         await dbContext.SaveChangesAsync(cancellationToken);
+
         await resourceEventPublisher.Publish(
-            processingErrorEntity
+            inserted
                 .ToResourceEvent(ResourceEventOperations.Created)
-                .WithChangeSet(processingErrorEntity.ProcessingError, new ProcessingError()),
+                .WithChangeSet(inserted.ProcessingError, new ProcessingError()),
             cancellationToken
         );
 
-        return processingErrorEntity;
+        return inserted;
     }
 
     public async Task<ProcessingErrorEntity> Update(
@@ -37,23 +41,21 @@ public class ProcessingErrorService(IDbContext dbContext, IResourceEventPublishe
         CancellationToken cancellationToken
     )
     {
-        var existing = await dbContext.ProcessingErrors.Find(processingErrorEntity.Id, cancellationToken);
-        if (existing == null)
-        {
-            throw new EntityNotFoundException(nameof(ProcessingErrorEntity), processingErrorEntity.Id);
-        }
-
-        processingErrorEntity.Created = existing.Created;
-
-        await dbContext.ProcessingErrors.Update(processingErrorEntity, etag, cancellationToken);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        await resourceEventPublisher.Publish(
-            processingErrorEntity
-                .ToResourceEvent(ResourceEventOperations.Updated)
-                .WithChangeSet(processingErrorEntity.ProcessingError, existing.ProcessingError),
+        var (existing, updated) = await processingErrorRepository.Update(
+            processingErrorEntity,
+            etag,
             cancellationToken
         );
 
-        return processingErrorEntity;
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        await resourceEventPublisher.Publish(
+            updated
+                .ToResourceEvent(ResourceEventOperations.Updated)
+                .WithChangeSet(updated.ProcessingError, existing.ProcessingError),
+            cancellationToken
+        );
+
+        return updated;
     }
 }

--- a/src/Data/Extensions/QueryableExtensions.cs
+++ b/src/Data/Extensions/QueryableExtensions.cs
@@ -4,7 +4,7 @@ namespace Defra.TradeImportsDataApi.Data.Extensions;
 
 public static class QueryableExtensions
 {
-    public static async Task<List<TSource>> ToListAsync<TSource>(
+    public static async Task<List<TSource>> ToListWithFallbackAsync<TSource>(
         this IQueryable<TSource> source,
         CancellationToken cancellationToken = default
     )

--- a/tests/Api.IntegrationTests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.IntegrationTests/Services/ImportPreNotificationServiceTests.cs
@@ -1,4 +1,5 @@
 using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Data.Mongo;
@@ -39,7 +40,8 @@ public class ImportPreNotificationServiceTests : IntegrationTestBase, IAsyncLife
         Subject = new ImportPreNotificationService(
             MongoDbContext,
             Substitute.For<IResourceEventPublisher>(),
-            NullLogger<ImportPreNotificationService>.Instance
+            new ImportPreNotificationRepository(MongoDbContext, NullLogger<ImportPreNotificationRepository>.Instance),
+            new CustomsDeclarationRepository(MongoDbContext)
         );
     }
 

--- a/tests/Api.Tests/Data/CustomsDeclarationRepositoryTests.cs
+++ b/tests/Api.Tests/Data/CustomsDeclarationRepositoryTests.cs
@@ -1,0 +1,32 @@
+using Defra.TradeImportsDataApi.Api.Data;
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Data;
+
+public class CustomsDeclarationRepositoryTests
+{
+    private IDbContext DbContext { get; }
+    private CustomsDeclarationRepository Subject { get; }
+
+    public CustomsDeclarationRepositoryTests()
+    {
+        DbContext = Substitute.For<IDbContext>();
+
+        Subject = new CustomsDeclarationRepository(DbContext);
+    }
+
+    [Fact]
+    public async Task Update_WhenNotExists_ShouldThrow()
+    {
+        var entity = new CustomsDeclarationEntity { Id = "id", ClearanceRequest = new ClearanceRequest() };
+
+        var act = async () => await Subject.Update(entity, "etag", CancellationToken.None);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+}

--- a/tests/Api.Tests/Data/GmrRepositoryTests.cs
+++ b/tests/Api.Tests/Data/GmrRepositoryTests.cs
@@ -1,0 +1,32 @@
+using Defra.TradeImportsDataApi.Api.Data;
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Domain.Gvms;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Data;
+
+public class GmrRepositoryTests
+{
+    private IDbContext DbContext { get; }
+    private GmrRepository Subject { get; }
+
+    public GmrRepositoryTests()
+    {
+        DbContext = Substitute.For<IDbContext>();
+
+        Subject = new GmrRepository(DbContext);
+    }
+
+    [Fact]
+    public async Task Update_WhenNotExists_ShouldThrow()
+    {
+        var entity = new GmrEntity { Id = "id", Gmr = new Gmr() };
+
+        var act = async () => await Subject.Update(entity, "etag", CancellationToken.None);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+}

--- a/tests/Api.Tests/Data/ImportPreNotificationRepositoryTests.cs
+++ b/tests/Api.Tests/Data/ImportPreNotificationRepositoryTests.cs
@@ -1,0 +1,33 @@
+using Defra.TradeImportsDataApi.Api.Data;
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Data;
+
+public class ImportPreNotificationRepositoryTests
+{
+    private IDbContext DbContext { get; }
+    private ImportPreNotificationRepository Subject { get; }
+
+    public ImportPreNotificationRepositoryTests()
+    {
+        DbContext = Substitute.For<IDbContext>();
+
+        Subject = new ImportPreNotificationRepository(DbContext, NullLogger<ImportPreNotificationRepository>.Instance);
+    }
+
+    [Fact]
+    public async Task Update_WhenNotExists_ShouldThrow()
+    {
+        var entity = new ImportPreNotificationEntity { Id = "id", ImportPreNotification = new ImportPreNotification() };
+
+        var act = async () => await Subject.Update(entity, "etag", CancellationToken.None);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+}

--- a/tests/Api.Tests/Data/ProcessingErrorRepositoryTests.cs
+++ b/tests/Api.Tests/Data/ProcessingErrorRepositoryTests.cs
@@ -1,0 +1,32 @@
+using Defra.TradeImportsDataApi.Api.Data;
+using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Domain.ProcessingErrors;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Data;
+
+public class ProcessingErrorRepositoryTests
+{
+    private IDbContext DbContext { get; }
+    private ProcessingErrorRepository Subject { get; }
+
+    public ProcessingErrorRepositoryTests()
+    {
+        DbContext = Substitute.For<IDbContext>();
+
+        Subject = new ProcessingErrorRepository(DbContext);
+    }
+
+    [Fact]
+    public async Task Update_WhenNotExists_ShouldThrow()
+    {
+        var entity = new ProcessingErrorEntity { Id = "id", ProcessingError = new ProcessingError() };
+
+        var act = async () => await Subject.Update(entity, "etag", CancellationToken.None);
+
+        await act.Should().ThrowAsync<EntityNotFoundException>();
+    }
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Testing;
 using FluentAssertions;

--- a/tests/Api.Tests/Services/GmrServiceTests.cs
+++ b/tests/Api.Tests/Services/GmrServiceTests.cs
@@ -1,5 +1,4 @@
-using System.Linq.Expressions;
-using Defra.TradeImportsDataApi.Api.Exceptions;
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
@@ -12,15 +11,36 @@ namespace Defra.TradeImportsDataApi.Api.Tests.Services;
 
 public class GmrServiceTests
 {
+    private IDbContext DbContext { get; }
+    private IGmrRepository GmrRepository { get; }
+    private IImportPreNotificationRepository ImportPreNotificationRepository { get; }
+    private ICustomsDeclarationRepository CustomsDeclarationRepository { get; }
+    private GmrService Subject { get; }
+
+    public GmrServiceTests()
+    {
+        DbContext = Substitute.For<IDbContext>();
+        GmrRepository = Substitute.For<IGmrRepository>();
+        ImportPreNotificationRepository = Substitute.For<IImportPreNotificationRepository>();
+        CustomsDeclarationRepository = Substitute.For<ICustomsDeclarationRepository>();
+
+        Subject = new GmrService(
+            DbContext,
+            GmrRepository,
+            ImportPreNotificationRepository,
+            CustomsDeclarationRepository
+        );
+    }
+
     [Fact]
     public async Task GetGmrByChedId_WhenChedDoesNotExist_ReturnsEmptyList()
     {
-        var mockDbContext = Substitute.For<IDbContext>();
-        var subject = new GmrService(mockDbContext);
-
         const string chedRef = "CHEDDY";
+        ImportPreNotificationRepository
+            .GetCustomsDeclarationIdentifier(chedRef, CancellationToken.None)
+            .Returns((string?)null);
 
-        var result = await subject.GetGmrByChedId(chedRef, CancellationToken.None);
+        var result = await Subject.GetGmrByChedId(chedRef, CancellationToken.None);
 
         result.Should().BeEmpty();
     }
@@ -28,9 +48,6 @@ public class GmrServiceTests
     [Fact]
     public async Task GetGmrByChedId_WhenChedExists_ButHasNoLinkedCustomsDeclarations_ReturnsEmptyList()
     {
-        var mockDbContext = Substitute.For<IDbContext>();
-        var subject = new GmrService(mockDbContext);
-
         const string chedRef = "CHEDDY";
         const string mrn = "mrn123";
 
@@ -41,19 +58,15 @@ public class GmrServiceTests
             ImportPreNotification = new ImportPreNotification(),
         };
 
-        mockDbContext
-            .ImportPreNotifications.Find(
-                Arg.Any<Expression<Func<ImportPreNotificationEntity, bool>>>(),
-                CancellationToken.None
-            )
-            .Returns(importNotification);
-        mockDbContext
-            .CustomsDeclarations.FindMany(
-                Arg.Any<Expression<Func<CustomsDeclarationEntity, bool>>>(),
-                CancellationToken.None
-            )
+        ImportPreNotificationRepository
+            .GetCustomsDeclarationIdentifier(chedRef, CancellationToken.None)
+            .Returns(importNotification.CustomsDeclarationIdentifier);
+
+        CustomsDeclarationRepository
+            .GetAllIds(importNotification.CustomsDeclarationIdentifier, CancellationToken.None)
             .Returns([]);
-        var result = await subject.GetGmrByChedId(chedRef, CancellationToken.None);
+
+        var result = await Subject.GetGmrByChedId(chedRef, CancellationToken.None);
 
         result.Should().BeEmpty();
     }
@@ -61,9 +74,6 @@ public class GmrServiceTests
     [Fact]
     public async Task GetGmrByChedId_WhenChedExists_AndHasLinkedCustomsDeclarations_ReturnsListOfGmrs()
     {
-        var mockDbContext = Substitute.For<IDbContext>();
-        var subject = new GmrService(mockDbContext);
-
         const string chedRef = "CHEDDY";
         const string mrn = "mrn123";
         const string gmr = "gmr123";
@@ -75,65 +85,41 @@ public class GmrServiceTests
             ImportPreNotification = new ImportPreNotification(),
         };
 
-        var customsDeclaration = new CustomsDeclarationEntity
-        {
-            Id = mrn,
-            ImportPreNotificationIdentifiers = [importNotification.Id],
-        };
+        ImportPreNotificationRepository
+            .GetCustomsDeclarationIdentifier(chedRef, CancellationToken.None)
+            .Returns(importNotification.CustomsDeclarationIdentifier);
 
-        mockDbContext
-            .ImportPreNotifications.Find(
-                Arg.Any<Expression<Func<ImportPreNotificationEntity, bool>>>(),
-                CancellationToken.None
-            )
-            .Returns(importNotification);
-        mockDbContext
-            .CustomsDeclarations.FindMany(
-                Arg.Any<Expression<Func<CustomsDeclarationEntity, bool>>>(),
-                CancellationToken.None
-            )
-            .Returns([customsDeclaration]);
-        mockDbContext
-            .Gmrs.FindMany(Arg.Any<Expression<Func<GmrEntity, bool>>>(), CancellationToken.None)
+        CustomsDeclarationRepository
+            .GetAllIds(importNotification.CustomsDeclarationIdentifier, CancellationToken.None)
+            .Returns([mrn]);
+
+        GmrRepository
+            .GetAll(Arg.Is<string[]>(x => x.SequenceEqual(new[] { mrn })), CancellationToken.None)
             .Returns([new GmrEntity { Id = gmr, Gmr = new Gmr() }]);
-        var result = await subject.GetGmrByChedId(chedRef, CancellationToken.None);
+
+        var result = await Subject.GetGmrByChedId(chedRef, CancellationToken.None);
 
         result.Count.Should().Be(1);
         result[0].Id.Should().Be(gmr);
     }
 
     [Fact]
-    public async Task Insert_ShouldInsertAndPublish()
+    public async Task Insert_ShouldInsert()
     {
-        var mockDbContext = Substitute.For<IDbContext>();
-        var subject = new GmrService(mockDbContext);
         var entity = new GmrEntity { Id = "id", Gmr = new Gmr() };
 
-        await subject.Insert(entity, CancellationToken.None);
+        await Subject.Insert(entity, CancellationToken.None);
 
-        await mockDbContext.Gmrs.Received().Insert(entity, CancellationToken.None);
-        await mockDbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await GmrRepository.Received().Insert(entity, CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
     }
 
     [Fact]
-    public async Task Update_WhenNotExists_ShouldThrow()
+    public async Task Update_ShouldUpdate()
     {
-        var mockDbContext = Substitute.For<IDbContext>();
-        var subject = new GmrService(mockDbContext);
-        var entity = new GmrEntity { Id = "id", Gmr = new Gmr() };
-
-        var act = async () => await subject.Update(entity, "etag", CancellationToken.None);
-
-        await act.Should().ThrowAsync<EntityNotFoundException>();
-    }
-
-    [Fact]
-    public async Task Update_ShouldUpdateAndPublish()
-    {
-        var mockDbContext = Substitute.For<IDbContext>();
         const string id = "id";
-        mockDbContext
-            .Gmrs.Find(id)
+        GmrRepository
+            .Get(id, CancellationToken.None)
             .Returns(
                 new GmrEntity
                 {
@@ -141,16 +127,26 @@ public class GmrServiceTests
                     Gmr = new Gmr { State = "OPEN" },
                 }
             );
-        var subject = new GmrService(mockDbContext);
         var entity = new GmrEntity
         {
             Id = id,
             Gmr = new Gmr { State = "COMPLETED" },
         };
 
-        await subject.Update(entity, "etag", CancellationToken.None);
+        await Subject.Update(entity, "etag", CancellationToken.None);
 
-        await mockDbContext.Gmrs.Received().Update(entity, "etag", CancellationToken.None);
-        await mockDbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await GmrRepository.Received().Update(entity, "etag", CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task GetGmr_ShouldReturn()
+    {
+        const string id = "id";
+        GmrRepository.Get(id, CancellationToken.None).Returns(new GmrEntity { Id = id, Gmr = new Gmr() });
+
+        var result = await Subject.GetGmr(id, CancellationToken.None);
+
+        result.Should().NotBeNull();
     }
 }

--- a/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
+++ b/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
@@ -1,3 +1,4 @@
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Endpoints.Search;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Api.Tests.Utils.InMemoryData;
@@ -5,6 +6,7 @@ using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Defra.TradeImportsDataApi.Api.Tests.Services;
 
@@ -14,7 +16,7 @@ public class RelatedImportDeclarationsServiceTests
     public async Task GivenSearchNothing_ThenShouldReturnEmpty()
     {
         var memoryDbContext = new MemoryDbContext();
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(new RelatedImportDeclarationsRequest(), CancellationToken.None);
 
@@ -40,7 +42,7 @@ public class RelatedImportDeclarationsServiceTests
             }
         );
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(new RelatedImportDeclarationsRequest { Mrn = mrn }, CancellationToken.None);
 
@@ -96,7 +98,7 @@ public class RelatedImportDeclarationsServiceTests
             }
         );
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(new RelatedImportDeclarationsRequest { Mrn = mrn }, CancellationToken.None);
 
@@ -122,7 +124,7 @@ public class RelatedImportDeclarationsServiceTests
             }
         );
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(
             new RelatedImportDeclarationsRequest { Ducr = "ducr123" },
@@ -180,7 +182,7 @@ public class RelatedImportDeclarationsServiceTests
             }
         );
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(
             new RelatedImportDeclarationsRequest { Ducr = "ducr123" },
@@ -213,7 +215,7 @@ public class RelatedImportDeclarationsServiceTests
             }
         );
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(
             new RelatedImportDeclarationsRequest { ChedId = searchChedId },
@@ -230,7 +232,7 @@ public class RelatedImportDeclarationsServiceTests
     {
         var memoryDbContext = new MemoryDbContext();
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(
             new RelatedImportDeclarationsRequest { ChedId = "1234567" },
@@ -248,7 +250,7 @@ public class RelatedImportDeclarationsServiceTests
         var memoryDbContext = new MemoryDbContext();
         InsertTestData(memoryDbContext);
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(
             new RelatedImportDeclarationsRequest { ChedId = "1234510" },
@@ -266,7 +268,7 @@ public class RelatedImportDeclarationsServiceTests
         var memoryDbContext = new MemoryDbContext();
         InsertTestData(memoryDbContext);
 
-        var subject = new RelatedImportDeclarationsService(memoryDbContext);
+        var subject = CreateSubject(memoryDbContext);
 
         var response = await subject.Search(
             new RelatedImportDeclarationsRequest { ChedId = "1234510", MaxLinkDepth = 1 },
@@ -312,6 +314,7 @@ public class RelatedImportDeclarationsServiceTests
                 DocumentCode = "C640",
             })
             .ToArray();
+
         return new CustomsDeclarationEntity
         {
             Id = mrn,
@@ -321,5 +324,13 @@ public class RelatedImportDeclarationsServiceTests
             Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
             ETag = "etag",
         };
+    }
+
+    private static RelatedImportDeclarationsService CreateSubject(MemoryDbContext memoryDbContext)
+    {
+        return new RelatedImportDeclarationsService(
+            new CustomsDeclarationRepository(memoryDbContext),
+            new ImportPreNotificationRepository(memoryDbContext, NullLogger<ImportPreNotificationRepository>.Instance)
+        );
     }
 }


### PR DESCRIPTION
During work on notification updates, there was friction working around the current use of the `IDbContext` in our services and other places in the codebase.

This made refactoring harder than it needed to be.

We have also got a relatively busy `IDbContext` implementation with methods that have come over from previous codebases and are now not used.

In implementing a repository layer, we get:

- Specific methods for retrieval of certain types of data
- We can minimise the data being requested from the DB in a more controlled manner
- We can reuse methods that were starting to be repeated
- We can protect our services in tests and mock any repositories
- We can test our repositories in integration tests instead
- We can refactor our repositories without affecting our logic/tests for services

This work paves the road for the next change that will be creating a denormalised "update" entity for an import pre notification, which will be the driver the update endpoint.