### PR TITLE
MongoDB exceptions that should be concurrency errors

### DIFF
--- a/src/Data/ConcurrencyException.cs
+++ b/src/Data/ConcurrencyException.cs
@@ -1,9 +1,18 @@
 namespace Defra.TradeImportsDataApi.Data;
 
-public class ConcurrencyException(string entityId, string entityEtag)
-    : Exception($"Failed up update {entityId} with etag {entityEtag}")
+public class ConcurrencyException : Exception
 {
-    public string EntityId { get; } = entityId;
+    public ConcurrencyException(string entityId, string entityEtag)
+        : base($"Failed up update {entityId} with etag {entityEtag}")
+    {
+        EntityId = entityId;
+        EntityEtag = entityEtag;
+    }
 
-    public string EntityEtag { get; } = entityEtag;
+    public ConcurrencyException(string message, Exception inner)
+        : base(message, inner) { }
+
+    public string? EntityId { get; }
+
+    public string? EntityEtag { get; }
 }

--- a/tests/Api.IntegrationTests/Endpoints/ImportPreNotificationUpdateTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ImportPreNotificationUpdateTests.cs
@@ -8,6 +8,7 @@ using Defra.TradeImportsDataApi.Domain.Gvms;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using Defra.TradeImportsDataApi.Testing;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using MongoDB.Driver;
 using ImportPreNotificationResponse = Defra.TradeImportsDataApi.Api.Client.ImportPreNotificationResponse;
 
@@ -39,7 +40,7 @@ public class ImportPreNotificationUpdateTests : IntegrationTestBase, IAsyncLifet
 
         DataApiClient = CreateDataApiClient();
         HttpClient = CreateHttpClient();
-        MongoDbContext = new MongoDbContext(GetMongoDatabase());
+        MongoDbContext = new MongoDbContext(GetMongoDatabase(), NullLogger<MongoDbContext>.Instance);
     }
 
     public Task DisposeAsync() => Task.CompletedTask;

--- a/tests/Api.IntegrationTests/Endpoints/RelatedImportDeclarationsTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/RelatedImportDeclarationsTests.cs
@@ -80,15 +80,13 @@ public class RelatedImportDeclarationsTests : IntegrationTestBase
         var chedRef4 = ImportPreNotificationIdGenerator.Generate();
         var random = Guid.NewGuid().ToString("N");
 
-        await Task.WhenAll(
-            CreateImportPreNotification(client, chedRef1),
-            CreateImportPreNotification(client, chedRef2),
-            CreateImportPreNotification(client, chedRef3),
-            CreateImportPreNotification(client, chedRef4),
-            CreateCustomsDeclaration(client, $"{random}-mrn1", $"{random}-ducr1", [chedRef3, chedRef4]),
-            CreateCustomsDeclaration(client, $"{random}-mrn2", $"{random}-ducr2", [chedRef2, chedRef3]),
-            CreateCustomsDeclaration(client, $"{random}-mrn3", $"{random}-ducr3", [chedRef1, chedRef2])
-        );
+        await CreateImportPreNotification(client, chedRef1);
+        await CreateImportPreNotification(client, chedRef2);
+        await CreateImportPreNotification(client, chedRef3);
+        await CreateImportPreNotification(client, chedRef4);
+        await CreateCustomsDeclaration(client, $"{random}-mrn1", $"{random}-ducr1", [chedRef3, chedRef4]);
+        await CreateCustomsDeclaration(client, $"{random}-mrn2", $"{random}-ducr2", [chedRef2, chedRef3]);
+        await CreateCustomsDeclaration(client, $"{random}-mrn3", $"{random}-ducr3", [chedRef1, chedRef2]);
 
         return (chedRef4, random);
     }


### PR DESCRIPTION
The main premise of the data API is for consumers to manage what exists and what doesn't exist and then act accordingly. If something does not exist then it should be created, however if two processes are checking for existence at the same time then they will both conclude nothing exists so they need to create it; which will result in a failure to write for one of the processes.

This is where our retry model within the consumer will kick in, therefore mitigating the failure to write first time around within the data API. And it will succeed on the second attempt as an update and not an insert.

In these scenarios, the data API is therefore handling concurrency issues and it should not write the problem as an unhandled exception. It's a known side effect of the consumption/write model we have implemented.

If we write them as is, they will contribute to CDP alerts and similar as they are errors from the service. We don't want this as it's normal system operation.

Therefore, in the scenario where a MongoDB exception is thrown for the following:

- WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction
- A write operation resulted in an error. WriteError: { Category : "DuplicateKey", Code : 11000 }

Handle the exception and return a `ConcurrencyException` instead, which will be converted to a `409 Conflict` as a response.

Also log the originating exception as a warning so we still track it.