### PR TITLE
Add safety check in case identifier is ever an empty string

### DIFF
--- a/src/Api/Endpoints/RelatedImportDeclarations/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/RelatedImportDeclarations/EndpointRouteBuilderExtensions.cs
@@ -2,10 +2,9 @@ using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 using Defra.TradeImportsDataApi.Api.Services;
-using Defra.TradeImportsDataApi.Data.Entities;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Defra.TradeImportsDataApi.Api.Endpoints.Search;
+namespace Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 
 public static class EndpointRouteBuilderExtensions
 {

--- a/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsRequest.cs
+++ b/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsRequest.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using Microsoft.AspNetCore.Mvc;
 
-namespace Defra.TradeImportsDataApi.Api.Endpoints.Search;
+namespace Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 
 public class RelatedImportDeclarationsRequest
 {

--- a/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsResponse.cs
+++ b/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsResponse.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 
-namespace Defra.TradeImportsDataApi.Api.Endpoints.Search;
+namespace Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 
 public record RelatedImportDeclarationsResponse(
     [property: JsonPropertyName("customsDeclarations")] CustomsDeclarationResponse[] CustomsDeclarations,

--- a/src/Api/Endpoints/Search/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/Search/EndpointRouteBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 using Defra.TradeImportsDataApi.Api.Services;
+using Defra.TradeImportsDataApi.Data.Entities;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Defra.TradeImportsDataApi.Api.Endpoints.Search;
@@ -37,7 +38,7 @@ public static class EndpointRouteBuilderExtensions
 
         var response = new RelatedImportDeclarationsResponse(
             searchResults
-                .CustomsDeclaration.Select(x => new CustomsDeclarationResponse(
+                .CustomsDeclarations.Select(x => new CustomsDeclarationResponse(
                     x.Id,
                     x.ClearanceRequest,
                     x.ClearanceDecision,

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -7,7 +7,7 @@ using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.Gmrs;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 using Defra.TradeImportsDataApi.Api.Endpoints.ProcessingErrors;
-using Defra.TradeImportsDataApi.Api.Endpoints.Search;
+using Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 using Defra.TradeImportsDataApi.Api.Health;
 using Defra.TradeImportsDataApi.Api.OpenApi;
 using Defra.TradeImportsDataApi.Api.Services;

--- a/src/Api/Services/IRelatedImportDeclarationsService.cs
+++ b/src/Api/Services/IRelatedImportDeclarationsService.cs
@@ -5,7 +5,7 @@ namespace Defra.TradeImportsDataApi.Api.Services;
 
 public interface IRelatedImportDeclarationsService
 {
-    Task<(CustomsDeclarationEntity[] CustomsDeclaration, ImportPreNotificationEntity[] ImportPreNotifications)> Search(
+    Task<(CustomsDeclarationEntity[] CustomsDeclarations, ImportPreNotificationEntity[] ImportPreNotifications)> Search(
         RelatedImportDeclarationsRequest request,
         CancellationToken cancellationToken
     );

--- a/src/Api/Services/IRelatedImportDeclarationsService.cs
+++ b/src/Api/Services/IRelatedImportDeclarationsService.cs
@@ -1,4 +1,4 @@
-using Defra.TradeImportsDataApi.Api.Endpoints.Search;
+using Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 using Defra.TradeImportsDataApi.Data.Entities;
 
 namespace Defra.TradeImportsDataApi.Api.Services;

--- a/src/Api/Services/RelatedImportDeclarationsService.cs
+++ b/src/Api/Services/RelatedImportDeclarationsService.cs
@@ -1,6 +1,6 @@
 using System.Linq.Expressions;
 using Defra.TradeImportsDataApi.Api.Data;
-using Defra.TradeImportsDataApi.Api.Endpoints.Search;
+using Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 using Defra.TradeImportsDataApi.Data.Entities;
 
 namespace Defra.TradeImportsDataApi.Api.Services;

--- a/src/Api/Services/RelatedImportDeclarationsService.cs
+++ b/src/Api/Services/RelatedImportDeclarationsService.cs
@@ -11,7 +11,7 @@ public class RelatedImportDeclarationsService(
 ) : IRelatedImportDeclarationsService
 {
     public async Task<(
-        CustomsDeclarationEntity[] CustomsDeclaration,
+        CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications
     )> Search(RelatedImportDeclarationsRequest request, CancellationToken cancellationToken)
     {
@@ -54,7 +54,7 @@ public class RelatedImportDeclarationsService(
     }
 
     private async Task<(
-        CustomsDeclarationEntity[] CustomsDeclaration,
+        CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications
     )> StartFromCustomsDeclaration(
         Expression<Func<CustomsDeclarationEntity, bool>> predicate,
@@ -78,7 +78,7 @@ public class RelatedImportDeclarationsService(
     }
 
     private async Task<(
-        CustomsDeclarationEntity[] CustomsDeclaration,
+        CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications
     )> StartFromImportPreNotification(string chedId, int maxDepth, CancellationToken cancellationToken)
     {
@@ -110,10 +110,10 @@ public class RelatedImportDeclarationsService(
     }
 
     private async Task<(
-        CustomsDeclarationEntity[] CustomsDeclaration,
+        CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications
     )> IncludeIndirectLinks(
-        (CustomsDeclarationEntity[] CustomsDeclaration, ImportPreNotificationEntity[] ImportPreNotifications) data,
+        (CustomsDeclarationEntity[] CustomsDeclarations, ImportPreNotificationEntity[] ImportPreNotifications) data,
         int currentDepth,
         int maxDepth,
         CancellationToken cancellationToken
@@ -124,13 +124,13 @@ public class RelatedImportDeclarationsService(
             return data;
         }
 
-        var customsDeclarations = data.CustomsDeclaration.ToList();
+        var customsDeclarations = data.CustomsDeclarations.ToList();
         var customsDeclarationIds = customsDeclarations.Select(x => x.Id);
         var importPreNotifications = data.ImportPreNotifications.ToList();
         var importPreNotificationIds = importPreNotifications.Select(x => x.Id);
 
         var identifiers = data
-            .CustomsDeclaration.SelectMany(x => x.ImportPreNotificationIdentifiers)
+            .CustomsDeclarations.SelectMany(x => x.ImportPreNotificationIdentifiers)
             .Union(data.ImportPreNotifications.Select(x => x.CustomsDeclarationIdentifier))
             .Distinct()
             .ToList();
@@ -163,7 +163,7 @@ public class RelatedImportDeclarationsService(
 
         // bail out of the recursive loop if there are no records loaded
         if (
-            response.Item1.Length == data.CustomsDeclaration.Length
+            response.Item1.Length == data.CustomsDeclarations.Length
             && response.Item2.Length == data.ImportPreNotifications.Length
         )
         {

--- a/src/Api/Services/RelatedImportDeclarationsService.cs
+++ b/src/Api/Services/RelatedImportDeclarationsService.cs
@@ -132,6 +132,7 @@ public class RelatedImportDeclarationsService(
         var identifiers = data
             .CustomsDeclarations.SelectMany(x => x.ImportPreNotificationIdentifiers)
             .Union(data.ImportPreNotifications.Select(x => x.CustomsDeclarationIdentifier))
+            .Where(x => !string.IsNullOrEmpty(x))
             .Distinct()
             .ToList();
 

--- a/tests/Api.Tests/Endpoints/Search/RelatedImportDeclarationsTests.cs
+++ b/tests/Api.Tests/Endpoints/Search/RelatedImportDeclarationsTests.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using Defra.TradeImportsDataApi.Api.Endpoints.Search;
+using Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;

--- a/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
+++ b/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
@@ -52,6 +52,48 @@ public class RelatedImportDeclarationsServiceTests
     }
 
     [Fact]
+    public async Task GivenSearchByMrn_WhenMrnExists_AndIdentifiersMatchesAnotherMrn_ThenShouldReturn()
+    {
+        const string mrn1 = "mrn1";
+        const string mrn2 = "mrn2";
+        var memoryDbContext = new MemoryDbContext();
+
+        memoryDbContext.CustomsDeclarations.AddTestData(
+            new CustomsDeclarationEntity
+            {
+                Id = mrn1,
+                ImportPreNotificationIdentifiers = [""],
+                ClearanceRequest = new ClearanceRequest(),
+                Created = new DateTime(2025, 4, 3, 10, 0, 0, DateTimeKind.Utc),
+                Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
+                ETag = "etag",
+            }
+        );
+        memoryDbContext.CustomsDeclarations.AddTestData(
+            new CustomsDeclarationEntity
+            {
+                Id = mrn2,
+                ImportPreNotificationIdentifiers = [""],
+                ClearanceRequest = new ClearanceRequest(),
+                Created = new DateTime(2025, 4, 3, 10, 0, 0, DateTimeKind.Utc),
+                Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
+                ETag = "etag",
+            }
+        );
+
+        var subject = CreateSubject(memoryDbContext);
+
+        var response = await subject.Search(
+            new RelatedImportDeclarationsRequest { Mrn = mrn1 },
+            CancellationToken.None
+        );
+
+        response.Should().NotBeNull();
+        response.CustomsDeclarations.Length.Should().Be(1);
+        response.ImportPreNotifications.Length.Should().Be(0);
+    }
+
+    [Fact]
     public async Task GivenSearchByMrn_WhenMrnExists_AndNotificationsExist_ThenShouldReturn()
     {
         const string mrn = "mrn";

--- a/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
+++ b/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
@@ -1,5 +1,5 @@
 using Defra.TradeImportsDataApi.Api.Data;
-using Defra.TradeImportsDataApi.Api.Endpoints.Search;
+using Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Api.Tests.Utils.InMemoryData;
 using Defra.TradeImportsDataApi.Data.Entities;

--- a/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
+++ b/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
@@ -21,7 +21,7 @@ public class RelatedImportDeclarationsServiceTests
         var response = await subject.Search(new RelatedImportDeclarationsRequest(), CancellationToken.None);
 
         response.ImportPreNotifications.Length.Should().Be(0);
-        response.CustomsDeclaration.Length.Should().Be(0);
+        response.CustomsDeclarations.Length.Should().Be(0);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public class RelatedImportDeclarationsServiceTests
         var response = await subject.Search(new RelatedImportDeclarationsRequest { Mrn = mrn }, CancellationToken.None);
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(1);
+        response.CustomsDeclarations.Length.Should().Be(1);
         response.ImportPreNotifications.Length.Should().Be(0);
     }
 
@@ -103,7 +103,7 @@ public class RelatedImportDeclarationsServiceTests
         var response = await subject.Search(new RelatedImportDeclarationsRequest { Mrn = mrn }, CancellationToken.None);
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(1);
+        response.CustomsDeclarations.Length.Should().Be(1);
         response.ImportPreNotifications.Length.Should().Be(1);
     }
 
@@ -132,7 +132,7 @@ public class RelatedImportDeclarationsServiceTests
         );
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(1);
+        response.CustomsDeclarations.Length.Should().Be(1);
         response.ImportPreNotifications.Length.Should().Be(0);
     }
 
@@ -190,7 +190,7 @@ public class RelatedImportDeclarationsServiceTests
         );
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(1);
+        response.CustomsDeclarations.Length.Should().Be(1);
         response.ImportPreNotifications.Length.Should().Be(1);
     }
 
@@ -223,7 +223,7 @@ public class RelatedImportDeclarationsServiceTests
         );
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(0);
+        response.CustomsDeclarations.Length.Should().Be(0);
         response.ImportPreNotifications.Length.Should().Be(1);
     }
 
@@ -240,7 +240,7 @@ public class RelatedImportDeclarationsServiceTests
         );
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(0);
+        response.CustomsDeclarations.Length.Should().Be(0);
         response.ImportPreNotifications.Length.Should().Be(0);
     }
 
@@ -258,7 +258,7 @@ public class RelatedImportDeclarationsServiceTests
         );
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(3);
+        response.CustomsDeclarations.Length.Should().Be(3);
         response.ImportPreNotifications.Length.Should().Be(4);
     }
 
@@ -276,7 +276,7 @@ public class RelatedImportDeclarationsServiceTests
         );
 
         response.Should().NotBeNull();
-        response.CustomsDeclaration.Length.Should().Be(2);
+        response.CustomsDeclarations.Length.Should().Be(2);
         response.ImportPreNotifications.Length.Should().Be(2);
     }
 


### PR DESCRIPTION
See comment https://eaflood.atlassian.net/browse/CDMS-740?focusedCommentId=744793

Yet we also now protect against identifiers being empty string values as it throws it our related search.

Also included are some renames to better place the code.