### PR TITLE
Remove custom Mongo logging

### DIFF
--- a/src/Api/Data/ImportPreNotificationRepository.cs
+++ b/src/Api/Data/ImportPreNotificationRepository.cs
@@ -38,7 +38,7 @@ public class ImportPreNotificationRepository(IDbContext dbContext, ILogger<Impor
         CancellationToken cancellationToken
     ) => await dbContext.ImportPreNotifications.Where(predicate).ToListWithFallbackAsync(cancellationToken);
 
-    public async Task<List<ImportPreNotificationUpdateEntity>> GetAllUpdates(
+    private async Task<List<ImportPreNotificationUpdateEntity>> GetAllUpdates(
         string[] ids,
         CancellationToken cancellationToken
     ) => await dbContext.ImportPreNotificationUpdates.Where(x => ids.Contains(x.Id)).ToListAsync(cancellationToken);

--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
     <PackageReference Include="MongoDB.Driver.Authentication.AWS" Version="3.4.0" />
-    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -7,7 +7,6 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 using MongoDB.Driver.Authentication.AWS;
-using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 
 namespace Defra.TradeImportsDataApi.Data.Extensions;
 
@@ -32,14 +31,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(sp =>
         {
             MongoClientSettings.Extensions.AddAWSAuthentication();
+
             var options = sp.GetService<IOptions<MongoDbOptions>>();
             var settings = MongoClientSettings.FromConnectionString(options?.Value.DatabaseUri);
-
-            settings.ClusterConfigurator = cb =>
-                cb.Subscribe(
-                    new DiagnosticsActivityEventSubscriber(new InstrumentationOptions { CaptureCommandText = true })
-                );
-
             var client = new MongoClient(settings);
             var conventionPack = new ConventionPack
             {

--- a/tests/Api.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Api.IntegrationTests/IntegrationTestBase.cs
@@ -3,7 +3,6 @@ using Defra.TradeImportsDataApi.Api.Client;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Extensions.DiagnosticSources;
 
 namespace Defra.TradeImportsDataApi.Api.IntegrationTests;
 
@@ -28,11 +27,6 @@ public abstract class IntegrationTestBase
     protected static IMongoDatabase GetMongoDatabase()
     {
         var settings = MongoClientSettings.FromConnectionString("mongodb://127.0.0.1:27017/?directConnection=true");
-
-        settings.ClusterConfigurator = cb =>
-            cb.Subscribe(
-                new DiagnosticsActivityEventSubscriber(new InstrumentationOptions { CaptureCommandText = true })
-            );
 
         return new MongoClient(settings).GetDatabase("trade-imports-data-api");
     }

--- a/tests/Api.Tests/Data/ImportPreNotificationRepositoryTests.cs
+++ b/tests/Api.Tests/Data/ImportPreNotificationRepositoryTests.cs
@@ -4,7 +4,6 @@ using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 
 namespace Defra.TradeImportsDataApi.Api.Tests.Data;
@@ -18,7 +17,7 @@ public class ImportPreNotificationRepositoryTests
     {
         DbContext = Substitute.For<IDbContext>();
 
-        Subject = new ImportPreNotificationRepository(DbContext, NullLogger<ImportPreNotificationRepository>.Instance);
+        Subject = new ImportPreNotificationRepository(DbContext);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
+++ b/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
@@ -6,7 +6,6 @@ using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Defra.TradeImportsDataApi.Api.Tests.Services;
 
@@ -372,7 +371,7 @@ public class RelatedImportDeclarationsServiceTests
     {
         return new RelatedImportDeclarationsService(
             new CustomsDeclarationRepository(memoryDbContext),
-            new ImportPreNotificationRepository(memoryDbContext, NullLogger<ImportPreNotificationRepository>.Instance)
+            new ImportPreNotificationRepository(memoryDbContext)
         );
     }
 }


### PR DESCRIPTION
We will tackle this as part of supporting the API.

Therefore, removing custom stuff that is there currently.

For now, we can profile against the DB directly.