### PR TITLE
Add ResourceId as message header

### DIFF
--- a/src/Api/Services/ResourceEventPublisher.cs
+++ b/src/Api/Services/ResourceEventPublisher.cs
@@ -33,6 +33,10 @@ public class ResourceEventPublisher(
                 nameof(@event.ResourceType),
                 new MessageAttributeValue { StringValue = @event.ResourceType, DataType = DataTypeString }
             },
+            {
+                nameof(@event.ResourceId),
+                new MessageAttributeValue { StringValue = @event.ResourceId, DataType = DataTypeString }
+            },
         };
 
         if (@event.SubResourceType is not null)

--- a/tests/Api.Tests/Services/ResourceEventPublisherTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventPublisherTests.cs
@@ -51,6 +51,8 @@ public class ResourceEventPublisherTests
                     x.TopicArn == "arn:topic-name"
                     && x.MessageAttributes.ContainsKey("ResourceType")
                     && x.MessageAttributes["ResourceType"].StringValue == "resourceType"
+                    && x.MessageAttributes.ContainsKey("ResourceId")
+                    && x.MessageAttributes["ResourceId"].StringValue == "resourceId"
                     && x.Message
                         == "{\"resourceId\":\"resourceId\",\"resourceType\":\"resourceType\",\"subResourceType\":null,\"operation\":\"operation\",\"resource\":null,\"etag\":null,\"timestamp\":\"2025-04-16T07:00:00Z\",\"changeSet\":[]}"
                 ),


### PR DESCRIPTION
This PR will allow consumers to log in a generic way, which will then show the ID of the resource being consumed.