### PR TITLE
Add pagination to notification updates endpoint

### DIFF
--- a/src/Api/Data/IImportPreNotificationRepository.cs
+++ b/src/Api/Data/IImportPreNotificationRepository.cs
@@ -25,14 +25,7 @@ public interface IImportPreNotificationRepository
     Task<string?> GetCustomsDeclarationIdentifier(string id, CancellationToken cancellationToken);
 
     Task<ImportPreNotificationUpdates> GetUpdates(
-        DateTime from,
-        DateTime to,
-        string[]? pointOfEntry = null,
-        string[]? type = null,
-        string[]? status = null,
-        string[]? excludeStatus = null,
-        int page = 1,
-        int pageSize = 100,
+        ImportPreNotificationUpdateQuery query,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Api/Data/IImportPreNotificationRepository.cs
+++ b/src/Api/Data/IImportPreNotificationRepository.cs
@@ -24,13 +24,15 @@ public interface IImportPreNotificationRepository
 
     Task<string?> GetCustomsDeclarationIdentifier(string id, CancellationToken cancellationToken);
 
-    Task<List<ImportPreNotificationUpdate>> GetUpdates(
+    Task<ImportPreNotificationUpdates> GetUpdates(
         DateTime from,
         DateTime to,
         string[]? pointOfEntry = null,
         string[]? type = null,
         string[]? status = null,
         string[]? excludeStatus = null,
+        int page = 1,
+        int pageSize = 100,
         CancellationToken cancellationToken = default
     );
 

--- a/src/Api/Data/ImportPreNotificationUpdateQuery.cs
+++ b/src/Api/Data/ImportPreNotificationUpdateQuery.cs
@@ -1,0 +1,12 @@
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public record ImportPreNotificationUpdateQuery(
+    DateTime From,
+    DateTime To,
+    string[]? PointOfEntry = null,
+    string[]? Type = null,
+    string[]? Status = null,
+    string[]? ExcludeStatus = null,
+    int Page = 1,
+    int PageSize = 100
+);

--- a/src/Api/Data/ImportPreNotificationUpdates.cs
+++ b/src/Api/Data/ImportPreNotificationUpdates.cs
@@ -1,0 +1,3 @@
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public record ImportPreNotificationUpdates(IReadOnlyList<ImportPreNotificationUpdate> Updates, int Total);

--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Defra.TradeImportsDataApi.Api.Authentication;
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.Gmrs;
 using Defra.TradeImportsDataApi.Api.Exceptions;
@@ -232,14 +233,16 @@ public static class EndpointRouteBuilderExtensions
         var page = request.Page.GetValueOrDefault();
         var pageSize = request.PageSize.GetValueOrDefault();
         var result = await importPreNotificationService.GetImportPreNotificationUpdates(
-            request.From,
-            request.To,
-            request.PointOfEntry,
-            request.Type,
-            request.Status,
-            request.ExcludeStatus,
-            page,
-            pageSize,
+            new ImportPreNotificationUpdateQuery(
+                request.From,
+                request.To,
+                request.PointOfEntry,
+                request.Type,
+                request.Status,
+                request.ExcludeStatus,
+                page,
+                pageSize
+            ),
             cancellationToken
         );
 

--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -229,6 +229,8 @@ public static class EndpointRouteBuilderExtensions
         CancellationToken cancellationToken
     )
     {
+        var page = request.Page.GetValueOrDefault();
+        var pageSize = request.PageSize.GetValueOrDefault();
         var result = await importPreNotificationService.GetImportPreNotificationUpdates(
             request.From,
             request.To,
@@ -236,8 +238,8 @@ public static class EndpointRouteBuilderExtensions
             request.Type,
             request.Status,
             request.ExcludeStatus,
-            request.Page.GetValueOrDefault(),
-            request.PageSize.GetValueOrDefault(),
+            page,
+            pageSize,
             cancellationToken
         );
 
@@ -246,7 +248,9 @@ public static class EndpointRouteBuilderExtensions
                 result
                     .Updates.Select(x => new ImportPreNotificationUpdateResponse(x.ReferenceNumber, x.Updated))
                     .ToList(),
-                result.Total
+                result.Total,
+                page,
+                pageSize
             )
         );
     }

--- a/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/EndpointRouteBuilderExtensions.cs
@@ -236,12 +236,17 @@ public static class EndpointRouteBuilderExtensions
             request.Type,
             request.Status,
             request.ExcludeStatus,
+            request.Page.GetValueOrDefault(),
+            request.PageSize.GetValueOrDefault(),
             cancellationToken
         );
 
         return Results.Ok(
             new ImportPreNotificationUpdatesResponse(
-                result.Select(x => new ImportPreNotificationUpdateResponse(x.ReferenceNumber, x.Updated)).ToList()
+                result
+                    .Updates.Select(x => new ImportPreNotificationUpdateResponse(x.ReferenceNumber, x.Updated))
+                    .ToList(),
+                result.Total
             )
         );
     }

--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesRequest.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesRequest.cs
@@ -13,6 +13,8 @@ public class ImportPreNotificationUpdatesRequest
     private readonly string[]? _type;
     private readonly string[]? _status;
     private readonly string[]? _excludeStatus;
+    private readonly int? _page;
+    private readonly int? _pageSize;
 
     [Description(
         "Filter import pre notifications updated at this date and time or after this date and time. "
@@ -64,6 +66,22 @@ public class ImportPreNotificationUpdatesRequest
         init => _excludeStatus = value;
     }
 
+    [Description("Page number (1-based). Defaults to 1 if not specified.")]
+    [FromQuery(Name = "page")]
+    public int? Page
+    {
+        get => _page ?? 1;
+        init => _page = value;
+    }
+
+    [Description("Number of items per page. Defaults to 100 if not specified")]
+    [FromQuery(Name = "pageSize")]
+    public int? PageSize
+    {
+        get => _pageSize ?? 100;
+        init => _pageSize = value;
+    }
+
     public class ImportPreNotificationUpdatesRequestValidator
         : ValidationEndpointFilter<ImportPreNotificationUpdatesRequest>
     {
@@ -77,6 +95,8 @@ public class ImportPreNotificationUpdatesRequest
                 .WithMessage(
                     $"Must not be more than {TimeSpan.FromHours(1).Duration().TotalHours} hour(s) of {nameof(From)}"
                 );
+            RuleFor(x => x.Page).GreaterThanOrEqualTo(1);
+            RuleFor(x => x.PageSize).GreaterThanOrEqualTo(1);
         }
     }
 }

--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesResponse.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesResponse.cs
@@ -4,5 +4,6 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 
 public record ImportPreNotificationUpdatesResponse(
     [property: JsonPropertyName("importPreNotificationUpdates")]
-        IReadOnlyList<ImportPreNotificationUpdateResponse> ImportPreNotificationUpdates
+        IReadOnlyList<ImportPreNotificationUpdateResponse> ImportPreNotificationUpdates,
+    [property: JsonPropertyName("total")] int Total
 );

--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesResponse.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesResponse.cs
@@ -5,5 +5,7 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
 public record ImportPreNotificationUpdatesResponse(
     [property: JsonPropertyName("importPreNotificationUpdates")]
         IReadOnlyList<ImportPreNotificationUpdateResponse> ImportPreNotificationUpdates,
-    [property: JsonPropertyName("total")] int Total
+    [property: JsonPropertyName("total")] int Total,
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("pageSize")] int PageSize
 );

--- a/src/Api/Services/IImportPreNotificationService.cs
+++ b/src/Api/Services/IImportPreNotificationService.cs
@@ -21,14 +21,7 @@ public interface IImportPreNotificationService
     );
 
     Task<ImportPreNotificationUpdates> GetImportPreNotificationUpdates(
-        DateTime from,
-        DateTime to,
-        string[]? pointOfEntry = null,
-        string[]? type = null,
-        string[]? status = null,
-        string[]? excludeStatus = null,
-        int page = 1,
-        int pageSize = 100,
-        CancellationToken cancellationToken = default
+        ImportPreNotificationUpdateQuery query,
+        CancellationToken cancellationToken
     );
 }

--- a/src/Api/Services/IImportPreNotificationService.cs
+++ b/src/Api/Services/IImportPreNotificationService.cs
@@ -20,13 +20,15 @@ public interface IImportPreNotificationService
         CancellationToken cancellationToken
     );
 
-    Task<List<ImportPreNotificationUpdate>> GetImportPreNotificationUpdates(
+    Task<ImportPreNotificationUpdates> GetImportPreNotificationUpdates(
         DateTime from,
         DateTime to,
         string[]? pointOfEntry = null,
         string[]? type = null,
         string[]? status = null,
         string[]? excludeStatus = null,
+        int page = 1,
+        int pageSize = 100,
         CancellationToken cancellationToken = default
     );
 }

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -70,25 +70,7 @@ public class ImportPreNotificationService(
     }
 
     public async Task<ImportPreNotificationUpdates> GetImportPreNotificationUpdates(
-        DateTime from,
-        DateTime to,
-        string[]? pointOfEntry = null,
-        string[]? type = null,
-        string[]? status = null,
-        string[]? excludeStatus = null,
-        int page = 1,
-        int pageSize = 100,
-        CancellationToken cancellationToken = default
-    ) =>
-        await importPreNotificationRepository.GetUpdates(
-            from,
-            to,
-            pointOfEntry,
-            type,
-            status,
-            excludeStatus,
-            page,
-            pageSize,
-            cancellationToken
-        );
+        ImportPreNotificationUpdateQuery query,
+        CancellationToken cancellationToken
+    ) => await importPreNotificationRepository.GetUpdates(query, cancellationToken);
 }

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -69,13 +69,15 @@ public class ImportPreNotificationService(
         return updated;
     }
 
-    public async Task<List<ImportPreNotificationUpdate>> GetImportPreNotificationUpdates(
+    public async Task<ImportPreNotificationUpdates> GetImportPreNotificationUpdates(
         DateTime from,
         DateTime to,
         string[]? pointOfEntry = null,
         string[]? type = null,
         string[]? status = null,
         string[]? excludeStatus = null,
+        int page = 1,
+        int pageSize = 100,
         CancellationToken cancellationToken = default
     ) =>
         await importPreNotificationRepository.GetUpdates(
@@ -85,6 +87,8 @@ public class ImportPreNotificationService(
             type,
             status,
             excludeStatus,
+            page,
+            pageSize,
             cancellationToken
         );
 }

--- a/src/Data/Mongo/MongoIndexService.cs
+++ b/src/Data/Mongo/MongoIndexService.cs
@@ -69,7 +69,8 @@ public class MongoIndexService(IMongoDatabase database, ILogger<MongoIndexServic
                 .Ascending(x => x.PointOfEntry)
                 .Ascending(x => x.ImportNotificationType)
                 .Ascending(x => x.Status)
-                .Ascending(x => x.Id),
+                .Ascending(x => x.Id)
+                .Ascending(x => x.Source!.Updated),
             cancellationToken: cancellationToken
         );
     }

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageLessThan1_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageLessThan1_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    Page: [
+      'Page' must be greater than or equal to '1'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeLessThan1_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeLessThan1_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    PageSize: [
+      'Page Size' must be greater than or equal to '1'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
@@ -4,5 +4,6 @@
       referenceNumber: CHEDPP.GB.2024.5194492,
       updated: 2025-05-21T08:51:00Z
     }
-  ]
+  ],
+  total: 1
 }

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
@@ -5,5 +5,7 @@
       updated: 2025-05-21T08:51:00Z
     }
   ],
-  total: 1
+  total: 1,
+  page: 1,
+  pageSize: 10
 }

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
@@ -118,14 +118,12 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
         var client = CreateClient();
         MockImportPreNotificationService
             .GetImportPreNotificationUpdates(
-                Arg.Any<DateTime>(),
-                Arg.Any<DateTime>(),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Any<int>(),
-                Arg.Any<int>(),
+                Arg.Is<ImportPreNotificationUpdateQuery>(query =>
+                    query.PointOfEntry == null
+                    && query.Type == null
+                    && query.Status == null
+                    && query.ExcludeStatus == null
+                ),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
@@ -155,14 +153,12 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
         await MockImportPreNotificationService
             .Received(1)
             .GetImportPreNotificationUpdates(
-                Arg.Any<DateTime>(),
-                Arg.Any<DateTime>(),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Is<string[]?>(x => x == null),
-                Arg.Any<int>(),
-                Arg.Any<int>(),
+                Arg.Is<ImportPreNotificationUpdateQuery>(query =>
+                    query.PointOfEntry == null
+                    && query.Type == null
+                    && query.Status == null
+                    && query.ExcludeStatus == null
+                ),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -181,14 +177,20 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
         const int pageSize = 10;
         MockImportPreNotificationService
             .GetImportPreNotificationUpdates(
-                from,
-                to,
-                Arg.Is<string[]?>(x => x != null && x.SequenceEqual(pointOfEntry)),
-                Arg.Is<string[]?>(x => x != null && x.SequenceEqual(type)),
-                Arg.Is<string[]?>(x => x != null && x.SequenceEqual(status)),
-                Arg.Is<string[]?>(x => x != null && x.SequenceEqual(excludeStatus)),
-                Arg.Is<int>(x => x == page),
-                Arg.Is<int>(x => x == pageSize),
+                Arg.Is<ImportPreNotificationUpdateQuery>(query =>
+                    query.From == from
+                    && query.To == to
+                    && query.PointOfEntry != null
+                    && query.PointOfEntry.SequenceEqual(pointOfEntry)
+                    && query.Type != null
+                    && query.Type.SequenceEqual(type)
+                    && query.Status != null
+                    && query.Status.SequenceEqual(status)
+                    && query.ExcludeStatus != null
+                    && query.ExcludeStatus.SequenceEqual(excludeStatus)
+                    && query.Page == page
+                    && query.PageSize == pageSize
+                ),
                 Arg.Any<CancellationToken>()
             )
             .Returns(

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
@@ -177,6 +177,8 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
         string[] type = ["CVEDA", "CVEDP"];
         string[] status = ["DRAFT", "SUBMITTED"];
         string[] excludeStatus = ["AMEND"];
+        const int page = 1;
+        const int pageSize = 10;
         MockImportPreNotificationService
             .GetImportPreNotificationUpdates(
                 from,
@@ -185,8 +187,8 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
                 Arg.Is<string[]?>(x => x != null && x.SequenceEqual(type)),
                 Arg.Is<string[]?>(x => x != null && x.SequenceEqual(status)),
                 Arg.Is<string[]?>(x => x != null && x.SequenceEqual(excludeStatus)),
-                Arg.Is<int>(x => x == 2),
-                Arg.Is<int>(x => x == 200),
+                Arg.Is<int>(x => x == page),
+                Arg.Is<int>(x => x == pageSize),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
@@ -210,8 +212,8 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
                     .Where(EndpointFilter.Type(type))
                     .Where(EndpointFilter.Status(status))
                     .Where(EndpointFilter.ExcludeStatus(excludeStatus))
-                    .Where(EndpointFilter.Page(2))
-                    .Where(EndpointFilter.PageSize(200))
+                    .Where(EndpointFilter.Page(page))
+                    .Where(EndpointFilter.PageSize(pageSize))
             )
         );
 

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
@@ -78,6 +78,41 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
     }
 
     [Fact]
+    public async Task Get_WhenInvalidRequest_PageLessThan1_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 15, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.Page(0))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_PageSizeLessThan1_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 15, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.Page(1))
+                    .Where(EndpointFilter.PageSize(0))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
     public async Task Get_WhenInvalidRequest_EmptyStringInArrays_ShouldCallWithNone()
     {
         var client = CreateClient();
@@ -89,15 +124,20 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
                 Arg.Is<string[]?>(x => x == null),
                 Arg.Is<string[]?>(x => x == null),
                 Arg.Is<string[]?>(x => x == null),
+                Arg.Any<int>(),
+                Arg.Any<int>(),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
-                [
-                    new ImportPreNotificationUpdate(
-                        "CHEDPP.GB.2024.5194492",
-                        new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc)
-                    ),
-                ]
+                new ImportPreNotificationUpdates(
+                    [
+                        new ImportPreNotificationUpdate(
+                            "CHEDPP.GB.2024.5194492",
+                            new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc)
+                        ),
+                    ],
+                    Total: 1
+                )
             );
 
         await client.GetAsync(
@@ -121,6 +161,8 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
                 Arg.Is<string[]?>(x => x == null),
                 Arg.Is<string[]?>(x => x == null),
                 Arg.Is<string[]?>(x => x == null),
+                Arg.Any<int>(),
+                Arg.Any<int>(),
                 Arg.Any<CancellationToken>()
             );
     }
@@ -143,15 +185,20 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
                 Arg.Is<string[]?>(x => x != null && x.SequenceEqual(type)),
                 Arg.Is<string[]?>(x => x != null && x.SequenceEqual(status)),
                 Arg.Is<string[]?>(x => x != null && x.SequenceEqual(excludeStatus)),
+                Arg.Is<int>(x => x == 2),
+                Arg.Is<int>(x => x == 200),
                 Arg.Any<CancellationToken>()
             )
             .Returns(
-                [
-                    new ImportPreNotificationUpdate(
-                        "CHEDPP.GB.2024.5194492",
-                        new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc)
-                    ),
-                ]
+                new ImportPreNotificationUpdates(
+                    [
+                        new ImportPreNotificationUpdate(
+                            "CHEDPP.GB.2024.5194492",
+                            new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc)
+                        ),
+                    ],
+                    Total: 1
+                )
             );
 
         var response = await client.GetAsync(
@@ -163,6 +210,8 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
                     .Where(EndpointFilter.Type(type))
                     .Where(EndpointFilter.Status(status))
                     .Where(EndpointFilter.ExcludeStatus(excludeStatus))
+                    .Where(EndpointFilter.Page(2))
+                    .Where(EndpointFilter.PageSize(200))
             )
         );
 

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -700,6 +700,26 @@
               },
               "description": "Filter import pre notifications by NOT IN status. Multiple should be specified as excludeStatus=A&excludeStatus=B etc."
             }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-based). Defaults to 1 if not specified.",
+            "schema": {
+              "type": "integer",
+              "description": "Page number (1-based). Defaults to 1 if not specified.",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page. Defaults to 100 if not specified",
+            "schema": {
+              "type": "integer",
+              "description": "Number of items per page. Defaults to 100 if not specified",
+              "format": "int32"
+            }
           }
         ],
         "responses": {
@@ -3622,6 +3642,10 @@
             "items": {
               "$ref": "#/components/schemas/Defra.TradeImportsDataApi.ImportPreNotificationUpdateResponse"
             }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -3646,6 +3646,14 @@
           "total": {
             "type": "integer",
             "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -127,26 +127,13 @@ public class ImportPreNotificationServiceTests
         var from = DateTime.UtcNow;
         var to = DateTime.UtcNow.AddDays(1);
         ImportPreNotificationRepository
-            .GetUpdates(
-                from: from,
-                to: to,
-                pointOfEntry: null,
-                type: null,
-                status: null,
-                excludeStatus: null,
-                cancellationToken: CancellationToken.None
-            )
+            .GetUpdates(new ImportPreNotificationUpdateQuery(from, to), cancellationToken: CancellationToken.None)
             .Returns(
                 new ImportPreNotificationUpdates([new ImportPreNotificationUpdate(id, DateTime.UtcNow)], Total: 1)
             );
 
         var result = await Subject.GetImportPreNotificationUpdates(
-            from: from,
-            to: to,
-            pointOfEntry: null,
-            type: null,
-            status: null,
-            excludeStatus: null,
+            new ImportPreNotificationUpdateQuery(from, to),
             cancellationToken: CancellationToken.None
         );
 

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -136,7 +136,9 @@ public class ImportPreNotificationServiceTests
                 excludeStatus: null,
                 cancellationToken: CancellationToken.None
             )
-            .Returns([new ImportPreNotificationUpdate(id, DateTime.UtcNow)]);
+            .Returns(
+                new ImportPreNotificationUpdates([new ImportPreNotificationUpdate(id, DateTime.UtcNow)], Total: 1)
+            );
 
         var result = await Subject.GetImportPreNotificationUpdates(
             from: from,
@@ -148,6 +150,8 @@ public class ImportPreNotificationServiceTests
             cancellationToken: CancellationToken.None
         );
 
-        result.Should().NotBeEmpty();
+        result.Should().NotBeNull();
+        result.Updates.Should().NotBeEmpty();
+        result.Total.Should().Be(1);
     }
 }

--- a/tests/Testing/EndpointFilter.cs
+++ b/tests/Testing/EndpointFilter.cs
@@ -27,4 +27,8 @@ public class EndpointFilter
         (statuses ?? []).Select(ExcludeStatus).ToArray();
 
     public static EndpointFilter ExcludeStatus(string status) => new($"excludeStatus={status}");
+
+    public static EndpointFilter Page(int page) => new($"page={page}");
+
+    public static EndpointFilter PageSize(int pageSize) => new($"pageSize={pageSize}");
 }


### PR DESCRIPTION
This PR includes paging when looking for updates to CHEDs and related data that might be linked to the CHED.

The max page size has not been decided yet so currently it's unbounded.