### PR TITLE
Change notification "updates" tracking so a document is created on each update so events stay immutable

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -38,6 +38,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ENVIRONMENT: local
+      AWS_EMF_ENVIRONMENT: Local
       AWS_EMF_NAMESPACE: Defra.TradeImportsDataApi
       PORT: 8080
       Mongo__DatabaseUri: mongodb://mongodb:27017/?directConnection=true

--- a/compose.yml
+++ b/compose.yml
@@ -39,7 +39,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       ENVIRONMENT: local
       AWS_EMF_ENVIRONMENT: Local
-      AWS_EMF_NAMESPACE: Defra.TradeImportsDataApi
+      AWS_EMF_NAMESPACE: REAL_VALUE_SET_BY_CDP
       PORT: 8080
       Mongo__DatabaseUri: mongodb://mongodb:27017/?directConnection=true
       AWS__ServiceUrl: http://localstack:4566

--- a/src/Api/Data/ImportPreNotificationRepository.cs
+++ b/src/Api/Data/ImportPreNotificationRepository.cs
@@ -96,18 +96,12 @@ public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreN
             new BsonDocument("$limit", query.PageSize),
         };
 
-        var mongoQuery = string.Join(",", aggregatePipeline.Select(x => x.ToString()));
-        Console.WriteLine(mongoQuery);
-
         var countPipeline = new[]
         {
             new BsonDocument("$match", where),
             new BsonDocument("$group", new BsonDocument { { "_id", "$importPreNotificationId" } }),
             new BsonDocument("$count", "total"),
         };
-
-        mongoQuery = string.Join(",", countPipeline.Select(x => x.ToString()));
-        Console.WriteLine(mongoQuery);
 
         var aggregateTask = dbContext.ImportPreNotificationUpdates.Collection.AggregateAsync<NotificationUpdate>(
             aggregatePipeline,

--- a/src/Api/Metrics/EmfExporter.cs
+++ b/src/Api/Metrics/EmfExporter.cs
@@ -18,7 +18,10 @@ public static class EmfExportExtensions
         if (enabled)
         {
             var ns = config.GetValue<string>("AWS_EMF_NAMESPACE");
-            EmfExporter.Init(builder.ApplicationServices.GetRequiredService<ILoggerFactory>(), ns!);
+            if (string.IsNullOrWhiteSpace(ns))
+                throw new InvalidOperationException("AWS_EMF_NAMESPACE is not set but metrics are enabled");
+
+            EmfExporter.Init(builder.ApplicationServices.GetRequiredService<ILoggerFactory>(), ns);
         }
 
         return builder;
@@ -28,28 +31,28 @@ public static class EmfExportExtensions
 [ExcludeFromCodeCoverage]
 public static class EmfExporter
 {
-    private static readonly MeterListener MeterListener = new();
-    private static ILogger _logger = null!;
-    private static ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
-    private static string? _awsNamespace;
+    private static readonly MeterListener s_meterListener = new();
+    private static ILogger s_logger = null!;
+    private static ILoggerFactory s_loggerFactory = NullLoggerFactory.Instance;
+    private static string? s_awsNamespace;
 
     public static void Init(ILoggerFactory loggerFactory, string? awsNamespace)
     {
-        _logger = loggerFactory.CreateLogger(nameof(EmfExporter));
-        _loggerFactory = loggerFactory;
-        _awsNamespace = awsNamespace;
-        MeterListener.InstrumentPublished = (instrument, listener) =>
+        s_logger = loggerFactory.CreateLogger(nameof(EmfExporter));
+        s_loggerFactory = loggerFactory;
+        s_awsNamespace = awsNamespace;
+
+        s_meterListener.InstrumentPublished = (instrument, listener) =>
         {
             if (instrument.Meter.Name is MetricsConstants.MetricNames.MeterName)
             {
                 listener.EnableMeasurementEvents(instrument);
             }
         };
-
-        MeterListener.SetMeasurementEventCallback<int>(OnMeasurementRecorded);
-        MeterListener.SetMeasurementEventCallback<long>(OnMeasurementRecorded);
-        MeterListener.SetMeasurementEventCallback<double>(OnMeasurementRecorded);
-        MeterListener.Start();
+        s_meterListener.SetMeasurementEventCallback<int>(OnMeasurementRecorded);
+        s_meterListener.SetMeasurementEventCallback<long>(OnMeasurementRecorded);
+        s_meterListener.SetMeasurementEventCallback<double>(OnMeasurementRecorded);
+        s_meterListener.Start();
     }
 
     private static void OnMeasurementRecorded<T>(
@@ -61,14 +64,16 @@ public static class EmfExporter
     {
         try
         {
-            using var metricsLogger = new MetricsLogger(_loggerFactory);
+            using var metricsLogger = new MetricsLogger(s_loggerFactory);
 
-            metricsLogger.SetNamespace(_awsNamespace);
+            metricsLogger.SetNamespace(s_awsNamespace);
             var dimensionSet = new DimensionSet();
+
             foreach (var tag in tags)
             {
                 if (string.IsNullOrWhiteSpace(tag.Value?.ToString()))
                     continue;
+
                 dimensionSet.AddDimension(tag.Key, tag.Value?.ToString());
             }
 
@@ -80,7 +85,7 @@ public static class EmfExporter
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to push EMF metric");
+            s_logger.LogError(ex, "Failed to push EMF metric");
         }
     }
 }

--- a/src/Api/appsettings.IntegrationTests.json
+++ b/src/Api/appsettings.IntegrationTests.json
@@ -1,6 +1,5 @@
 {
-  "AWS_EMF_ENABLED": true,
-  "AWS_EMF_NAMESPACE": "Defra.TradeImportsDataApi",
+  "AWS_EMF_ENABLED": false,
   "Mongo": {
     "DatabaseUri": "mongodb://127.0.0.1:27017",
     "DatabaseName": "trade-imports-data-api-integration-tests"

--- a/src/Data/Entities/ImportPreNotificationUpdateEntity.cs
+++ b/src/Data/Entities/ImportPreNotificationUpdateEntity.cs
@@ -12,6 +12,8 @@ public class ImportPreNotificationUpdateEntity : IDataEntity
 
     public DateTime Updated { get; set; }
 
+    public required string ImportPreNotificationId { get; set; }
+
     public string? PointOfEntry { get; set; }
 
     public string? ImportNotificationType { get; set; }

--- a/src/Data/Mongo/MongoIndexService.cs
+++ b/src/Data/Mongo/MongoIndexService.cs
@@ -69,8 +69,8 @@ public class MongoIndexService(IMongoDatabase database, ILogger<MongoIndexServic
                 .Ascending(x => x.PointOfEntry)
                 .Ascending(x => x.ImportNotificationType)
                 .Ascending(x => x.Status)
-                .Ascending(x => x.Id)
-                .Ascending(x => x.Source!.Updated),
+                .Ascending(x => x.Source!.Updated)
+                .Ascending(x => x.ImportPreNotificationId),
             cancellationToken: cancellationToken
         );
     }


### PR DESCRIPTION
A problem with the previous implementation was highlighted when paging comes into play. As the update entity was itself being updated if it existed already, it was technically possible for notifications to appear as if they were moving pages; if, for example, an update for the notification came in at the same time as a series of pages of updates being requested.

Therefore we now switch to an update document that is created once for a given notification ID. It cannot change therefore it can never appear to move pages. If an update for the same notification is handled, a new update document will be created.

When requesting the data, it's grouped by notification ID and the latest updated field from the source reference is returned.

Also included is a metrics change whereby metrics cannot be enabled if the namespace is not set. An exception will be thrown. As well as `AWS_EMF_ENVIRONMENT` being set in the `compose.yml` so any metric logging is sent to the console. Sadly it only seems like `AWS_EMF_ENVIRONMENT` works when it's set as an env var and it can't be injected into our web application factory tests, therefore metrics are just turned off there.

One outstanding question is how long do we want to retain "updates". The data itself has a timely nature and should therefore not be kept around forever as it will just burden the system and take up storage. We may want to consider a TTL of a year or something perhaps?