### PR TITLE
Set max page size of 1000

### DIFF
--- a/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesRequest.cs
+++ b/src/Api/Endpoints/ImportPreNotifications/ImportPreNotificationUpdatesRequest.cs
@@ -74,7 +74,7 @@ public class ImportPreNotificationUpdatesRequest
         init => _page = value;
     }
 
-    [Description("Number of items per page. Defaults to 100 if not specified")]
+    [Description("Number of items per page. Defaults to 100 if not specified. Max of 1000.")]
     [FromQuery(Name = "pageSize")]
     public int? PageSize
     {
@@ -97,6 +97,7 @@ public class ImportPreNotificationUpdatesRequest
                 );
             RuleFor(x => x.Page).GreaterThanOrEqualTo(1);
             RuleFor(x => x.PageSize).GreaterThanOrEqualTo(1);
+            RuleFor(x => x.PageSize).LessThanOrEqualTo(1000);
         }
     }
 }

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeGreaterThan1000_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeGreaterThan1000_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    PageSize: [
+      'Page Size' must be less than or equal to '1000'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeGreaterThan2500_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeGreaterThan2500_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    PageSize: [
+      'Page Size' must be less than or equal to '2500'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/ImportPreNotifications/GetUpdatesTests.cs
@@ -113,6 +113,24 @@ public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
     }
 
     [Fact]
+    public async Task Get_WhenInvalidRequest_PageSizeGreaterThan1000_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.ImportPreNotifications.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 15, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.Page(1))
+                    .Where(EndpointFilter.PageSize(1001))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
     public async Task Get_WhenInvalidRequest_EmptyStringInArrays_ShouldCallWithNone()
     {
         var client = CreateClient();

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -714,10 +714,10 @@
           {
             "name": "pageSize",
             "in": "query",
-            "description": "Number of items per page. Defaults to 100 if not specified",
+            "description": "Number of items per page. Defaults to 100 if not specified. Max of 1000.",
             "schema": {
               "type": "integer",
-              "description": "Number of items per page. Defaults to 100 if not specified",
+              "description": "Number of items per page. Defaults to 100 if not specified. Max of 1000.",
               "format": "int32"
             }
           }


### PR DESCRIPTION
Based on some crude testing, a max page size of 1000 seems reasonable.

Tested when ~100k updates within an hour window are present. Response time ~1-1.5 seconds.