### PR TITLE
Add basic mongo query logging for development

### DIFF
--- a/src/Api/appsettings.Development.json
+++ b/src/Api/appsettings.Development.json
@@ -1,7 +1,8 @@
 {
   "Mongo": {
     "DatabaseUri": "mongodb://127.0.0.1:27017/?directConnection=true",
-    "DatabaseName": "trade-imports-data-api"
+    "DatabaseName": "trade-imports-data-api",
+    "QueryLogging": true
   },
   "AWS": {
     "ServiceUrl": "http://localstack:4566",

--- a/src/Api/appsettings.cdp.dev.json
+++ b/src/Api/appsettings.cdp.dev.json
@@ -1,4 +1,7 @@
 {
+  "Mongo": {
+    "QueryLogging": true
+  },
   "ResourceEvents": {
     "ArnPrefix": "arn:aws:sns:eu-west-2:332499610595"
   }

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -62,7 +62,7 @@ public static class ServiceCollectionExtensions
             ConventionRegistry.Register(nameof(conventionPack), conventionPack, _ => true);
             DomainClassMapConfiguration.Register();
 
-            return client.GetDatabase(options?.Value.DatabaseName);
+            return client.GetDatabase(options.Value.DatabaseName);
         });
 
         return services;

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,15 @@
+using System.Collections.Concurrent;
 using Defra.TradeImportsDataApi.Data.Configuration;
 using Defra.TradeImportsDataApi.Data.Mongo;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
 using MongoDB.Driver.Authentication.AWS;
+using MongoDB.Driver.Core.Events;
 
 namespace Defra.TradeImportsDataApi.Data.Extensions;
 
@@ -28,12 +31,27 @@ public static class ServiceCollectionExtensions
 
         services.AddHostedService<MongoIndexService>();
         services.AddScoped<IDbContext, MongoDbContext>();
+        services.AddSingleton<MongoCommandTracker>();
         services.AddSingleton(sp =>
         {
             MongoClientSettings.Extensions.AddAWSAuthentication();
 
-            var options = sp.GetService<IOptions<MongoDbOptions>>();
-            var settings = MongoClientSettings.FromConnectionString(options?.Value.DatabaseUri);
+            var options =
+                sp.GetService<IOptions<MongoDbOptions>>() ?? throw new InvalidOperationException("Options not found");
+            var settings = MongoClientSettings.FromConnectionString(options.Value.DatabaseUri);
+
+            if (options.Value.QueryLogging)
+            {
+                var commandTracker = sp.GetRequiredService<MongoCommandTracker>();
+
+                settings.ClusterConfigurator = cb =>
+                {
+                    cb.Subscribe<CommandStartedEvent>(commandTracker.OnCommandStarted);
+                    cb.Subscribe<CommandSucceededEvent>(commandTracker.OnCommandSucceeded);
+                    cb.Subscribe<CommandFailedEvent>(commandTracker.OnCommandFailed);
+                };
+            }
+
             var client = new MongoClient(settings);
             var conventionPack = new ConventionPack
             {
@@ -48,5 +66,46 @@ public static class ServiceCollectionExtensions
         });
 
         return services;
+    }
+
+    private sealed class MongoCommandTracker(ILogger<MongoCommandTracker> logger)
+    {
+        private readonly ConcurrentDictionary<long, Command> _commands = new();
+
+        private sealed record Command(string CommandName, string Query, long Timestamp);
+
+        public void OnCommandStarted(CommandStartedEvent @event)
+        {
+            if (@event.OperationId is not null && ShouldTrack(@event))
+                _commands.TryAdd(
+                    @event.OperationId.Value,
+                    new Command(@event.CommandName, @event.Command.ToJson(), TimeProvider.System.GetTimestamp())
+                );
+        }
+
+        public void OnCommandSucceeded(CommandSucceededEvent @event)
+        {
+            if (@event.OperationId is not null && _commands.TryRemove(@event.OperationId.Value, out var commandInfo))
+                Log(LogLevel.Information, commandInfo);
+        }
+
+        public void OnCommandFailed(CommandFailedEvent @event)
+        {
+            if (@event.OperationId is not null && _commands.TryRemove(@event.OperationId.Value, out var commandInfo))
+                Log(LogLevel.Warning, commandInfo);
+        }
+
+        private void Log(LogLevel level, Command command) =>
+            logger.Log(
+                level,
+                "Mongo query {Result} {CommandName} {Query} took {Duration}ms",
+                level == LogLevel.Information ? "succeeded" : "failed",
+                command.CommandName,
+                command.Query,
+                TimeProvider.System.GetElapsedTime(command.Timestamp).TotalMilliseconds
+            );
+
+        private static bool ShouldTrack(CommandStartedEvent @event) =>
+            @event.CommandName is "find" or "aggregate" or "count" or "distinct";
     }
 }

--- a/src/Data/MongoDbOptions.cs
+++ b/src/Data/MongoDbOptions.cs
@@ -11,4 +11,6 @@ public class MongoDbOptions
 
     [Required]
     public string? DatabaseName { get; set; }
+
+    public bool QueryLogging { get; set; }
 }


### PR DESCRIPTION
Turned on in development and also the CDP dev environment, include logging of any queries being made so we can trace anything that looks incorrect.

This also facilitated confirming the following query used the index regardless of search casing:

```
db.getCollection("CustomsDeclaration").aggregate(
[{ "$match" : { "clearanceRequest.declarationUcr" : { "$regularExpression" : { "pattern" : "^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$", "options" : "is" } } } }]
)
```

```
{
    "explainVersion" : "1",
    "queryPlanner" : {
        "namespace" : "trade-imports-data-api.CustomsDeclaration",
        "indexFilterSet" : false,
        "parsedQuery" : {
            "clearanceRequest.declarationUcr" : {
                "$regex" : "^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$",
                "$options" : "is"
            }
        },
        "queryHash" : "7AD8F36D",
        "planCacheKey" : "415138B4",
        "optimizedPipeline" : true,
        "maxIndexedOrSolutionsReached" : false,
        "maxIndexedAndSolutionsReached" : false,
        "maxScansToExplodeReached" : false,
        "winningPlan" : {
            "stage" : "FETCH",
            "inputStage" : {
                "stage" : "IXSCAN",
                "filter" : {
                    "clearanceRequest.declarationUcr" : {
                        "$regex" : "^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$",
                        "$options" : "is"
                    }
                },
                "keyPattern" : {
                    "clearanceRequest.declarationUcr" : NumberInt(1)
                },
                "indexName" : "DeclarationUcrIdx",
                "isMultiKey" : false,
                "multiKeyPaths" : {
                    "clearanceRequest.declarationUcr" : [

                    ]
                },
                "isUnique" : false,
                "isSparse" : false,
                "isPartial" : false,
                "indexVersion" : NumberInt(2),
                "direction" : "forward",
                "indexBounds" : {
                    "clearanceRequest.declarationUcr" : [
                        "[\"\", {})",
                        "[/^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$/is, /^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$/is]"
                    ]
                }
            }
        },
        "rejectedPlans" : [

        ]
    },
    "executionStats" : {
        "executionSuccess" : true,
        "nReturned" : NumberInt(0),
        "executionTimeMillis" : NumberInt(0),
        "totalKeysExamined" : NumberInt(3),
        "totalDocsExamined" : NumberInt(0),
        "executionStages" : {
            "stage" : "FETCH",
            "nReturned" : NumberInt(0),
            "executionTimeMillisEstimate" : NumberInt(0),
            "works" : NumberInt(4),
            "advanced" : NumberInt(0),
            "needTime" : NumberInt(3),
            "needYield" : NumberInt(0),
            "saveState" : NumberInt(0),
            "restoreState" : NumberInt(0),
            "isEOF" : NumberInt(1),
            "docsExamined" : NumberInt(0),
            "alreadyHasObj" : NumberInt(0),
            "inputStage" : {
                "stage" : "IXSCAN",
                "filter" : {
                    "clearanceRequest.declarationUcr" : {
                        "$regex" : "^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$",
                        "$options" : "is"
                    }
                },
                "nReturned" : NumberInt(0),
                "executionTimeMillisEstimate" : NumberInt(0),
                "works" : NumberInt(4),
                "advanced" : NumberInt(0),
                "needTime" : NumberInt(3),
                "needYield" : NumberInt(0),
                "saveState" : NumberInt(0),
                "restoreState" : NumberInt(0),
                "isEOF" : NumberInt(1),
                "keyPattern" : {
                    "clearanceRequest.declarationUcr" : NumberInt(1)
                },
                "indexName" : "DeclarationUcrIdx",
                "isMultiKey" : false,
                "multiKeyPaths" : {
                    "clearanceRequest.declarationUcr" : [

                    ]
                },
                "isUnique" : false,
                "isSparse" : false,
                "isPartial" : false,
                "indexVersion" : NumberInt(2),
                "direction" : "forward",
                "indexBounds" : {
                    "clearanceRequest.declarationUcr" : [
                        "[\"\", {})",
                        "[/^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$/is, /^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$/is]"
                    ]
                },
                "keysExamined" : NumberInt(3),
                "seeks" : NumberInt(1),
                "dupsTested" : NumberInt(0),
                "dupsDropped" : NumberInt(0)
            }
        }
    },
    "command" : {
        "aggregate" : "CustomsDeclaration",
        "pipeline" : [
            {
                "$match" : {
                    "clearanceRequest.declarationUcr" : /^21b8f085d58b42fbb81ce47c8c2ff503-ducr1$/is
                }
            }
        ],
        "maxTimeMS" : NumberLong(0),
        "cursor" : {

        },
        "$db" : "trade-imports-data-api"
    },
    "serverInfo" : {
        "host" : "94896925aea1",
        "port" : NumberInt(27017),
        "version" : "6.0.13",
        "gitVersion" : "3b13907f9bdf6bd3264d67140d6c215d51bbd20c"
    },
    "serverParameters" : {
        "internalQueryFacetBufferSizeBytes" : NumberInt(104857600),
        "internalQueryFacetMaxOutputDocSizeBytes" : NumberInt(104857600),
        "internalLookupStageIntermediateDocumentMaxSizeBytes" : NumberInt(104857600),
        "internalDocumentSourceGroupMaxMemoryBytes" : NumberInt(104857600),
        "internalQueryMaxBlockingSortMemoryUsageBytes" : NumberInt(104857600),
        "internalQueryProhibitBlockingMergeOnMongoS" : NumberInt(0),
        "internalQueryMaxAddToSetBytes" : NumberInt(104857600),
        "internalDocumentSourceSetWindowFieldsMaxMemoryBytes" : NumberInt(104857600)
    },
    "ok" : 1.0,
    "$clusterTime" : {
        "clusterTime" : Timestamp(1750083482, 1),
        "signature" : {
            "hash" : BinData(0, "AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
            "keyId" : NumberLong(0)
        }
    },
    "operationTime" : Timestamp(1750083482, 1)
}
```
