### PR TITLE
Ignore certain paths for request metrics if they start with specific values

### DIFF
--- a/src/Api/Metrics/MetricsMiddleware.cs
+++ b/src/Api/Metrics/MetricsMiddleware.cs
@@ -5,10 +5,13 @@ namespace Defra.TradeImportsDataApi.Api.Metrics;
 [ExcludeFromCodeCoverage]
 public class MetricsMiddleware(RequestMetrics requestMetrics) : IMiddleware
 {
+    private static readonly string[] s_startsWith = ["/apple-", "/favicon", "/redoc", "/.well-known/openapi"];
+
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         var startingTimestamp = TimeProvider.System.GetTimestamp();
         var path = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText ?? context.Request.Path;
+
         try
         {
             await next(context);
@@ -19,12 +22,17 @@ public class MetricsMiddleware(RequestMetrics requestMetrics) : IMiddleware
         }
         finally
         {
-            requestMetrics.RequestCompleted(
-                path,
-                context.Request.Method,
-                context.Response.StatusCode,
-                TimeProvider.System.GetElapsedTime(startingTimestamp).TotalMilliseconds
-            );
+            if (!IgnoreRequest(path))
+            {
+                requestMetrics.RequestCompleted(
+                    path,
+                    context.Request.Method,
+                    context.Response.StatusCode,
+                    TimeProvider.System.GetElapsedTime(startingTimestamp).TotalMilliseconds
+                );
+            }
         }
     }
+
+    private static bool IgnoreRequest(string path) => s_startsWith.Any(path.StartsWith);
 }

--- a/src/Api/Metrics/RequestMetrics.cs
+++ b/src/Api/Metrics/RequestMetrics.cs
@@ -6,40 +6,40 @@ namespace Defra.TradeImportsDataApi.Api.Metrics;
 
 public class RequestMetrics
 {
-    private readonly Counter<long> requestsReceived;
-    private readonly Counter<long> requestsFaulted;
-    private readonly Histogram<double> requestDuration;
+    private readonly Counter<long> _requestsReceived;
+    private readonly Counter<long> _requestsFaulted;
+    private readonly Histogram<double> _requestDuration;
 
     public RequestMetrics(IMeterFactory meterFactory)
     {
         var meter = meterFactory.Create(MetricsConstants.MetricNames.MeterName);
 
-        requestsReceived = meter.CreateCounter<long>(
+        _requestsReceived = meter.CreateCounter<long>(
             "RequestReceived",
-            Unit.COUNT.ToString(),
+            nameof(Unit.COUNT),
             "Count of messages received"
         );
 
-        requestDuration = meter.CreateHistogram<double>(
+        _requestDuration = meter.CreateHistogram<double>(
             "RequestDuration",
-            Unit.MILLISECONDS.ToString(),
+            nameof(Unit.MILLISECONDS),
             "Duration of request"
         );
 
-        requestsFaulted = meter.CreateCounter<long>("RequestFaulted", Unit.COUNT.ToString(), "Count of request faults");
+        _requestsFaulted = meter.CreateCounter<long>("RequestFaulted", nameof(Unit.COUNT), "Count of request faults");
     }
 
     public void RequestCompleted(string requestPath, string httpMethod, int statusCode, double milliseconds)
     {
-        requestsReceived.Add(1, BuildTags(requestPath, httpMethod, statusCode));
-        requestDuration.Record(milliseconds, BuildTags(requestPath, httpMethod, statusCode));
+        _requestsReceived.Add(1, BuildTags(requestPath, httpMethod, statusCode));
+        _requestDuration.Record(milliseconds, BuildTags(requestPath, httpMethod, statusCode));
     }
 
     public void RequestFaulted(string requestPath, string httpMethod, int statusCode, Exception exception)
     {
         var tagList = BuildTags(requestPath, httpMethod, statusCode);
         tagList.Add(MetricsConstants.RequestTags.ExceptionType, exception.GetType().Name);
-        requestsFaulted.Add(1, tagList);
+        _requestsFaulted.Add(1, tagList);
     }
 
     private static TagList BuildTags(string requestPath, string httpMethod, int statusCode)


### PR DESCRIPTION
As per PR title.

We have seen some paths make it into our request logs that we are not interested in, therefore we start to ignore paths in this PR.