### PR TITLE
Add defensive checks so we don't query Mongo if we don't have to

### DIFF
--- a/src/Api/Data/CustomsDeclarationRepository.cs
+++ b/src/Api/Data/CustomsDeclarationRepository.cs
@@ -9,18 +9,28 @@ namespace Defra.TradeImportsDataApi.Api.Data;
 
 public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclarationRepository
 {
-    public async Task<CustomsDeclarationEntity?> Get(string id, CancellationToken cancellationToken) =>
-        await dbContext.CustomsDeclarations.Find(id, cancellationToken);
+    public async Task<CustomsDeclarationEntity?> Get(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+
+        return await dbContext.CustomsDeclarations.Find(id, cancellationToken);
+    }
 
     public async Task<List<CustomsDeclarationEntity>> GetAll(
         string importPreNotificationIdentifier,
         CancellationToken cancellationToken
-    ) =>
-        await dbContext
+    )
+    {
+        if (string.IsNullOrWhiteSpace(importPreNotificationIdentifier))
+            return [];
+
+        return await dbContext
             .CustomsDeclarations.Where(x =>
                 x.ImportPreNotificationIdentifiers.Contains(importPreNotificationIdentifier)
             )
             .ToListWithFallbackAsync(cancellationToken);
+    }
 
     public async Task<List<CustomsDeclarationEntity>> GetAll(
         Expression<Func<CustomsDeclarationEntity, bool>> predicate,
@@ -30,32 +40,47 @@ public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclar
     public async Task<List<string>> GetAllIds(
         string importPreNotificationIdentifier,
         CancellationToken cancellationToken
-    ) =>
-        await dbContext
+    )
+    {
+        if (string.IsNullOrWhiteSpace(importPreNotificationIdentifier))
+            return [];
+
+        return await dbContext
             .CustomsDeclarations.Where(x =>
                 x.ImportPreNotificationIdentifiers.Contains(importPreNotificationIdentifier)
             )
             .Select(x => x.Id)
             .Distinct()
             .ToListWithFallbackAsync(cancellationToken);
+    }
 
     public async Task<List<string>> GetAllImportPreNotificationIdentifiers(
         string id,
         CancellationToken cancellationToken
-    ) =>
-        await dbContext
+    )
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return [];
+
+        return await dbContext
             .CustomsDeclarations.Where(x => x.Id == id)
             .SelectMany(x => x.ImportPreNotificationIdentifiers)
             .ToListAsync(cancellationToken);
+    }
 
     public async Task<List<string>> GetAllImportPreNotificationIdentifiers(
         string[] ids,
         CancellationToken cancellationToken
-    ) =>
-        await dbContext
+    )
+    {
+        if (ids.Length == 0)
+            return [];
+
+        return await dbContext
             .CustomsDeclarations.Where(x => ids.Contains(x.Id))
             .SelectMany(x => x.ImportPreNotificationIdentifiers)
             .ToListAsync(cancellationToken);
+    }
 
     public async Task<CustomsDeclarationEntity> Insert(
         CustomsDeclarationEntity entity,

--- a/src/Api/Data/GmrRepository.cs
+++ b/src/Api/Data/GmrRepository.cs
@@ -6,14 +6,24 @@ namespace Defra.TradeImportsDataApi.Api.Data;
 
 public class GmrRepository(IDbContext dbContext) : IGmrRepository
 {
-    public Task<GmrEntity?> Get(string id, CancellationToken cancellationToken) =>
-        dbContext.Gmrs.Find(id, cancellationToken);
+    public async Task<GmrEntity?> Get(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
 
-    public async Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken) =>
-        await dbContext.Gmrs.FindMany(
+        return await dbContext.Gmrs.Find(id, cancellationToken);
+    }
+
+    public async Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken)
+    {
+        if (customsDeclarationIds.Length == 0)
+            return [];
+
+        return await dbContext.Gmrs.FindMany(
             x => x.CustomsDeclarationIdentifiers.Any(id => customsDeclarationIds.Any(cId => cId == id)),
             cancellationToken
         );
+    }
 
     public async Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken)
     {

--- a/src/Api/Data/ImportPreNotificationRepository.cs
+++ b/src/Api/Data/ImportPreNotificationRepository.cs
@@ -11,37 +11,57 @@ namespace Defra.TradeImportsDataApi.Api.Data;
 
 public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreNotificationRepository
 {
-    public async Task<ImportPreNotificationEntity?> Get(string id, CancellationToken cancellationToken) =>
-        await dbContext.ImportPreNotifications.Find(id, cancellationToken);
+    public async Task<ImportPreNotificationEntity?> Get(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+
+        return await dbContext.ImportPreNotifications.Find(id, cancellationToken);
+    }
 
     public async Task<ImportPreNotificationEntity?> GetByCustomsDeclarationIdentifier(
         string customsDeclarationIdentifier,
         CancellationToken cancellationToken
-    ) =>
-        (
+    )
+    {
+        if (string.IsNullOrWhiteSpace(customsDeclarationIdentifier))
+            return null;
+
+        return (
             await dbContext
                 .ImportPreNotifications.Where(x => x.CustomsDeclarationIdentifier == customsDeclarationIdentifier)
                 .ToListWithFallbackAsync(cancellationToken)
         ).SingleOrDefault();
+    }
 
     public async Task<List<ImportPreNotificationEntity>> GetAll(
         string[] customsDeclarationIdentifiers,
         CancellationToken cancellationToken
-    ) =>
-        await dbContext
+    )
+    {
+        if (customsDeclarationIdentifiers.Length == 0)
+            return [];
+
+        return await dbContext
             .ImportPreNotifications.Where(x => customsDeclarationIdentifiers.Contains(x.CustomsDeclarationIdentifier))
             .ToListWithFallbackAsync(cancellationToken);
+    }
 
     public async Task<List<ImportPreNotificationEntity>> GetAll(
         Expression<Func<ImportPreNotificationEntity, bool>> predicate,
         CancellationToken cancellationToken
     ) => await dbContext.ImportPreNotifications.Where(predicate).ToListWithFallbackAsync(cancellationToken);
 
-    public async Task<string?> GetCustomsDeclarationIdentifier(string id, CancellationToken cancellationToken) =>
-        await dbContext
+    public async Task<string?> GetCustomsDeclarationIdentifier(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+
+        return await dbContext
             .ImportPreNotifications.Where(x => x.Id == id)
             .Select(x => x.CustomsDeclarationIdentifier)
             .FirstOrDefaultAsync(cancellationToken);
+    }
 
     public async Task<ImportPreNotificationUpdates> GetUpdates(
         ImportPreNotificationUpdateQuery query,

--- a/src/Api/Data/ProcessingErrorRepository.cs
+++ b/src/Api/Data/ProcessingErrorRepository.cs
@@ -6,8 +6,13 @@ namespace Defra.TradeImportsDataApi.Api.Data;
 
 public class ProcessingErrorRepository(IDbContext dbContext) : IProcessingErrorRepository
 {
-    public async Task<ProcessingErrorEntity?> Get(string id, CancellationToken cancellationToken) =>
-        await dbContext.ProcessingErrors.Find(id, cancellationToken);
+    public async Task<ProcessingErrorEntity?> Get(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            return null;
+
+        return await dbContext.ProcessingErrors.Find(id, cancellationToken);
+    }
 
     public async Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
We have observed several Mongo queries where it's looking for an empty array or similar. Therefore, there is no reason to call Mongo if we don't expect to find anything.

As such, this PR adds some defensive checks so we bail early in methods if there is nothing to find.