### PR TITLE
Allow the latest ID for each data type to be retrieved via a new admin endpoint that the performance tests will use

### DIFF
--- a/src/Api/Endpoints/Admin/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/Admin/EndpointRouteBuilderExtensions.cs
@@ -1,0 +1,43 @@
+using Defra.TradeImportsDataApi.Api.Authentication;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Extensions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.Admin;
+
+public static class EndpointRouteBuilderExtensions
+{
+    public static void MapAdminEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("admin/latest", Latest).ExcludeFromDescription().RequireAuthorization(PolicyNames.Read);
+    }
+
+    [HttpGet]
+    private static async Task<IResult> Latest([FromServices] IDbContext dbContext, CancellationToken cancellationToken)
+    {
+        var latestNotification = await dbContext
+            .ImportPreNotifications.OrderByDescending(x => x.Updated)
+            .FirstOrDefaultWithFallbackAsync(cancellationToken);
+
+        var latestCustomsDeclaration = await dbContext
+            .CustomsDeclarations.OrderByDescending(x => x.Updated)
+            .FirstOrDefaultWithFallbackAsync(cancellationToken);
+
+        var latestGmr = await dbContext
+            .Gmrs.OrderByDescending(x => x.Updated)
+            .FirstOrDefaultWithFallbackAsync(cancellationToken);
+
+        var latestProcessingError = await dbContext
+            .ProcessingErrors.OrderByDescending(x => x.Updated)
+            .FirstOrDefaultWithFallbackAsync(cancellationToken);
+
+        return Results.Ok(
+            new LatestResponse(
+                latestNotification?.Id,
+                latestCustomsDeclaration?.Id,
+                latestGmr?.Id,
+                latestProcessingError?.Id
+            )
+        );
+    }
+}

--- a/src/Api/Endpoints/Admin/LatestResponse.cs
+++ b/src/Api/Endpoints/Admin/LatestResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.Admin;
+
+public record LatestResponse(
+    [property: JsonPropertyName("importPreNotification")] string? ImportPreNotification,
+    [property: JsonPropertyName("customsDeclaration")] string? CustomsDeclaration,
+    [property: JsonPropertyName("gmr")] string? Gmr,
+    [property: JsonPropertyName("processingError")] string? ProcessingError
+);

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -3,6 +3,7 @@ using Amazon.SimpleNotificationService;
 using Defra.TradeImportsDataApi.Api.Authentication;
 using Defra.TradeImportsDataApi.Api.Configuration;
 using Defra.TradeImportsDataApi.Api.Data;
+using Defra.TradeImportsDataApi.Api.Endpoints.Admin;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Endpoints.Gmrs;
 using Defra.TradeImportsDataApi.Api.Endpoints.ImportPreNotifications;
@@ -138,6 +139,7 @@ static WebApplication BuildWebApplication(WebApplicationBuilder builder, bool ge
     app.MapCustomsDeclarationEndpoints();
     app.MapProcessingErrorEndpoints();
     app.MapSearchEndpoints();
+    app.MapAdminEndpoints();
     app.UseOpenApi();
     app.UseStatusCodePages();
     app.UseExceptionHandler(

--- a/src/Api/appsettings.json
+++ b/src/Api/appsettings.json
@@ -67,6 +67,11 @@
         "Scopes": [
           "read"
         ]
+      },
+      "PerformanceTest": {
+        "Scopes": [
+          "read"
+        ]
       }
     }
   },

--- a/src/Data/Extensions/QueryableExtensions.cs
+++ b/src/Data/Extensions/QueryableExtensions.cs
@@ -16,4 +16,17 @@ public static class QueryableExtensions
 
         return source.AsEnumerable().ToList();
     }
+
+    public static async Task<TSource?> FirstOrDefaultWithFallbackAsync<TSource>(
+        this IQueryable<TSource> source,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (source is IAsyncCursorSource<TSource> cursorSource)
+        {
+            return await cursorSource.FirstOrDefaultAsync(cancellationToken);
+        }
+
+        return source.AsEnumerable().FirstOrDefault();
+    }
 }

--- a/tests/Api.IntegrationTests/Endpoints/AdminTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/AdminTests.cs
@@ -1,0 +1,59 @@
+using System.Net.Http.Json;
+using Defra.TradeImportsDataApi.Api.Endpoints.Admin;
+using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Gvms;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+
+namespace Defra.TradeImportsDataApi.Api.IntegrationTests.Endpoints;
+
+public class AdminTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task WhenDataExists_ShouldReturn()
+    {
+        var client = CreateDataApiClient();
+        var chedRef1 = ImportPreNotificationIdGenerator.Generate();
+
+        await client.PutImportPreNotification(
+            chedRef1,
+            new ImportPreNotification { ReferenceNumber = chedRef1, Version = 1 },
+            null,
+            CancellationToken.None
+        );
+        await Task.Delay(1);
+        var chedRef2 = ImportPreNotificationIdGenerator.Generate();
+        await client.PutImportPreNotification(
+            chedRef2,
+            new ImportPreNotification { ReferenceNumber = chedRef2, Version = 1 },
+            null,
+            CancellationToken.None
+        );
+
+        var mrn1 = Guid.NewGuid().ToString();
+        await client.PutCustomsDeclaration(mrn1, new CustomsDeclaration(), null, CancellationToken.None);
+        await Task.Delay(1);
+        var mrn2 = Guid.NewGuid().ToString();
+        await client.PutCustomsDeclaration(mrn2, new CustomsDeclaration(), null, CancellationToken.None);
+
+        var gmr1 = Guid.NewGuid().ToString();
+        await client.PutGmr(gmr1, new Gmr(), null, CancellationToken.None);
+        await Task.Delay(1);
+        var gmr2 = Guid.NewGuid().ToString();
+        await client.PutGmr(gmr2, new Gmr(), null, CancellationToken.None);
+
+        await client.PutProcessingError(mrn1, [], null, CancellationToken.None);
+        await Task.Delay(1);
+        await client.PutProcessingError(mrn2, [], null, CancellationToken.None);
+
+        var httpClient = CreateHttpClient();
+        var dto = await httpClient.GetFromJsonAsync<LatestResponse>(Testing.Endpoints.Admin.Latest);
+
+        dto.Should().NotBeNull();
+        dto.ImportPreNotification.Should().Be(chedRef2);
+        dto.CustomsDeclaration.Should().Be(mrn2);
+        dto.Gmr.Should().Be(gmr2);
+        dto.ProcessingError.Should().Be(mrn2);
+    }
+}

--- a/tests/Api.Tests/Endpoints/Admin/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.txt
+++ b/tests/Api.Tests/Endpoints/Admin/GetTests.Get_WhenAuthorized_ShouldBeOk.verified.txt
@@ -1,0 +1,6 @@
+﻿{
+  importPreNotification: CHED,
+  customsDeclaration: CDS,
+  gmr: GMR,
+  processingError: ProcessingError
+}

--- a/tests/Api.Tests/Endpoints/Admin/GetTests.cs
+++ b/tests/Api.Tests/Endpoints/Admin/GetTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Defra.TradeImportsDataApi.Api.Tests.Utils.InMemoryData;
+using Defra.TradeImportsDataApi.Data;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Domain.Gvms;
+using Defra.TradeImportsDataApi.Domain.Ipaffs;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using WireMock.Server;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Endpoints.Admin;
+
+public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
+{
+    private WireMockServer WireMock { get; }
+    private readonly VerifySettings _settings;
+    private MemoryDbContext DbContext { get; } = new();
+
+    public GetTests(ApiWebApplicationFactory factory, ITestOutputHelper outputHelper, WireMockContext context)
+        : base(factory, outputHelper)
+    {
+        WireMock = context.Server;
+        WireMock.Reset();
+
+        _settings = new VerifySettings();
+        _settings.ScrubMember("traceId");
+        _settings.DontScrubDateTimes();
+        _settings.DontScrubGuids();
+        _settings.DontIgnoreEmptyCollections();
+    }
+
+    protected override void ConfigureTestServices(IServiceCollection services)
+    {
+        base.ConfigureTestServices(services);
+
+        services.AddTransient<IDbContext>(_ => DbContext);
+    }
+
+    [Fact]
+    public async Task Get_WhenUnauthorized_ShouldBeUnauthorized()
+    {
+        var client = CreateClient(addDefaultAuthorizationHeader: false);
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.Admin.Latest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_WhenWriteOnly_ShouldBeForbidden()
+    {
+        var client = CreateClient(testUser: TestUser.WriteOnly);
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.Admin.Latest);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Get_WhenAuthorized_ShouldBeOk()
+    {
+        var client = CreateClient();
+
+        DbContext.ImportPreNotifications.AddTestData(
+            new ImportPreNotificationEntity { Id = "CHED", ImportPreNotification = new ImportPreNotification() }
+        );
+        DbContext.CustomsDeclarations.AddTestData(new CustomsDeclarationEntity { Id = "CDS" });
+        DbContext.Gmrs.AddTestData(new GmrEntity { Id = "GMR", Gmr = new Gmr() });
+        DbContext.ProcessingErrors.AddTestData(
+            new ProcessingErrorEntity { Id = "ProcessingError", ProcessingErrors = [] }
+        );
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.Admin.Latest);
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+}

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -52,4 +52,9 @@ public static class Endpoints
 
         public static string Put(string mrn) => $"{Root}/{mrn}";
     }
+
+    public static class Admin
+    {
+        public static string Latest => "/admin/latest";
+    }
 }


### PR DESCRIPTION
As per PR title.

Performance tests need a way to determine that latest notification ID so the number can be incremented from a starting point on subsequent runs.

All data types have been included when returning the "latest" stored.

Latest is determined by the `Updated` field of each entity.

The new endpoint responds on `/admin/latest` and requires the `read` scope.

The endpoints do not appear in our public open API spec.