### PR TITLE
Include Split Consignment within identifier 

### DIFF
--- a/src/Domain/CustomsDeclaration/ChedReferenceRegexes.cs
+++ b/src/Domain/CustomsDeclaration/ChedReferenceRegexes.cs
@@ -5,6 +5,6 @@ namespace Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 // <summary> Common Health Entry Document reference regular expressions. </summary>
 public static partial class ChedReferenceRegexes
 {
-    [GeneratedRegex("\\d{2,4}\\.?\\d{7}", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
+    [GeneratedRegex("\\d{7}(v|r)?$", RegexOptions.Compiled | RegexOptions.IgnoreCase)]
     internal static partial Regex DocumentReferenceIdentifier();
 }

--- a/src/Domain/CustomsDeclaration/ImportDocumentReference.cs
+++ b/src/Domain/CustomsDeclaration/ImportDocumentReference.cs
@@ -15,13 +15,7 @@ public class ImportDocumentReference(string value)
     {
         if (!IsValid(documentCode))
             return string.Empty;
-        var identifier = ChedReferenceRegexes.DocumentReferenceIdentifier().Match(Value).Value.Replace(".", "");
-
-        if (identifier.Length > 7)
-        {
-            identifier = identifier.Substring(identifier.Length - 7);
-        }
-
-        return identifier;
+        var identifier = ChedReferenceRegexes.DocumentReferenceIdentifier().Match(Value);
+        return identifier.Value;
     }
 }

--- a/src/Domain/Ipaffs/ChedIdReference.cs
+++ b/src/Domain/Ipaffs/ChedIdReference.cs
@@ -8,18 +8,13 @@ public class ChedIdReference(string value)
 
     public string GetIdentifier()
     {
-        var identifier = ChedReferenceRegexes.DocumentReferenceIdentifier().Match(Value).Value.Replace(".", "");
+        var identifier = ChedReferenceRegexes.DocumentReferenceIdentifier().Match(Value);
 
         if (identifier.Length == 0)
         {
             throw new FormatException($"Invalid value {Value}");
         }
 
-        if (identifier.Length > 7)
-        {
-            identifier = identifier.Substring(identifier.Length - 7);
-        }
-
-        return identifier;
+        return identifier.Value;
     }
 }

--- a/tests/Api.Tests/Domain/ChedIdReferenceTests.cs
+++ b/tests/Api.Tests/Domain/ChedIdReferenceTests.cs
@@ -7,8 +7,8 @@ public class ChedIdReferenceTests
 {
     [Theory]
     [InlineData("CHEDA.GB.2025.1234567", "1234567")]
-    [InlineData("CHEDA.GB.2025.1234567R", "1234567")]
-    [InlineData("CHEDA.GB.2025.12345678", "1234567")]
+    [InlineData("CHEDA.GB.2025.1234567R", "1234567R")]
+    [InlineData("CHEDA.GB.2025.12345678", "2345678")]
     public void ValidTests(string chedId, string identifier)
     {
         new ChedIdReference(chedId).GetIdentifier().Should().Be(identifier);

--- a/tests/Api.Tests/Domain/ImportDocumentReferenceTests.cs
+++ b/tests/Api.Tests/Domain/ImportDocumentReferenceTests.cs
@@ -21,8 +21,11 @@ public class ImportDocumentReferenceTests
 
     [Theory]
     [InlineData("CHEDA.GB.2025.1234567", "C640", "1234567")]
-    [InlineData("CHEDA.GB.2025.12345678", "C640", "1234567")]
+    [InlineData("CHEDA.GB.2025.12345678", "C640", "2345678")]
     [InlineData("CHEDA.GB.2025.123456", "C678", null)]
+    [InlineData("GBCHDN.2025.1234567R", "C640", "1234567R")]
+    [InlineData("GBCHDN.2025..1234567R", "C640", "1234567R")]
+    [InlineData("GBCHDN.20251234567R", "C640", "1234567R")]
     public void GetIdentifier(string documentReference, string documentCode, string? identifier)
     {
         if (string.IsNullOrEmpty(identifier))


### PR DESCRIPTION
Changed the regex to look at the last 7 digits, but also include the last char is its V or R.

Previously it would take the first 7 digits, so this might be a breaking change for some tests.