### PR TITLE
Prevent the raw path from appearing in metrics as it might contain sensitive data

### DIFF
--- a/src/Api/Metrics/MetricsMiddleware.cs
+++ b/src/Api/Metrics/MetricsMiddleware.cs
@@ -10,7 +10,7 @@ public class MetricsMiddleware(RequestMetrics requestMetrics) : IMiddleware
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
         var startingTimestamp = TimeProvider.System.GetTimestamp();
-        var path = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText ?? context.Request.Path;
+        var path = (context.GetEndpoint() as RouteEndpoint)?.RoutePattern.RawText ?? "unknown";
 
         try
         {


### PR DESCRIPTION
As per PR title.