### PR TITLE
CDMS-917: Ensure data is not persisted if the resource event for certain entities cannot be written to SNS

### DIFF
--- a/src/Api/Data/CustomsDeclarationRepository.cs
+++ b/src/Api/Data/CustomsDeclarationRepository.cs
@@ -82,12 +82,9 @@ public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclar
             .ToListAsync(cancellationToken);
     }
 
-    public async Task<CustomsDeclarationEntity> Insert(
-        CustomsDeclarationEntity entity,
-        CancellationToken cancellationToken
-    )
+    public CustomsDeclarationEntity Insert(CustomsDeclarationEntity entity)
     {
-        await dbContext.CustomsDeclarations.Insert(entity, cancellationToken);
+        dbContext.CustomsDeclarations.Insert(entity);
 
         return entity;
     }
@@ -106,7 +103,7 @@ public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclar
 
         entity.Created = existing.Created;
 
-        await dbContext.CustomsDeclarations.Update(entity, etag, cancellationToken);
+        dbContext.CustomsDeclarations.Update(entity, etag);
 
         return (existing, entity);
     }

--- a/src/Api/Data/GmrRepository.cs
+++ b/src/Api/Data/GmrRepository.cs
@@ -25,9 +25,9 @@ public class GmrRepository(IDbContext dbContext) : IGmrRepository
         );
     }
 
-    public async Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken)
+    public GmrEntity Insert(GmrEntity entity)
     {
-        await dbContext.Gmrs.Insert(entity, cancellationToken);
+        dbContext.Gmrs.Insert(entity);
 
         return entity;
     }
@@ -46,7 +46,7 @@ public class GmrRepository(IDbContext dbContext) : IGmrRepository
 
         entity.Created = existing.Created;
 
-        await dbContext.Gmrs.Update(entity, etag, cancellationToken);
+        dbContext.Gmrs.Update(entity, etag);
 
         return (existing, entity);
     }

--- a/src/Api/Data/ICustomsDeclarationRepository.cs
+++ b/src/Api/Data/ICustomsDeclarationRepository.cs
@@ -23,7 +23,7 @@ public interface ICustomsDeclarationRepository
 
     Task<List<string>> GetAllImportPreNotificationIdentifiers(string[] ids, CancellationToken cancellationToken);
 
-    Task<CustomsDeclarationEntity> Insert(CustomsDeclarationEntity entity, CancellationToken cancellationToken);
+    CustomsDeclarationEntity Insert(CustomsDeclarationEntity entity);
 
     Task<(CustomsDeclarationEntity Existing, CustomsDeclarationEntity Updated)> Update(
         CustomsDeclarationEntity entity,

--- a/src/Api/Data/IGmrRepository.cs
+++ b/src/Api/Data/IGmrRepository.cs
@@ -8,7 +8,7 @@ public interface IGmrRepository
 
     Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken);
 
-    Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken);
+    GmrEntity Insert(GmrEntity entity);
 
     Task<(GmrEntity Existing, GmrEntity Updated)> Update(
         GmrEntity entity,

--- a/src/Api/Data/IImportPreNotificationRepository.cs
+++ b/src/Api/Data/IImportPreNotificationRepository.cs
@@ -29,7 +29,7 @@ public interface IImportPreNotificationRepository
         CancellationToken cancellationToken = default
     );
 
-    Task<ImportPreNotificationEntity> Insert(ImportPreNotificationEntity entity, CancellationToken cancellationToken);
+    ImportPreNotificationEntity Insert(ImportPreNotificationEntity entity);
 
     Task<(ImportPreNotificationEntity Existing, ImportPreNotificationEntity Updated)> Update(
         ImportPreNotificationEntity entity,
@@ -43,7 +43,7 @@ public interface IImportPreNotificationRepository
         CancellationToken cancellationToken
     );
 
-    Task TrackImportPreNotificationUpdate(ImportPreNotificationEntity entity, CancellationToken cancellationToken);
+    void TrackImportPreNotificationUpdate(ImportPreNotificationEntity entity);
 
     Task<string?> GetMaxId(CancellationToken cancellationToken);
 }

--- a/src/Api/Data/IProcessingErrorRepository.cs
+++ b/src/Api/Data/IProcessingErrorRepository.cs
@@ -6,7 +6,7 @@ public interface IProcessingErrorRepository
 {
     Task<ProcessingErrorEntity?> Get(string id, CancellationToken cancellationToken);
 
-    Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken);
+    ProcessingErrorEntity Insert(ProcessingErrorEntity entity);
 
     Task<(ProcessingErrorEntity Existing, ProcessingErrorEntity Updated)> Update(
         ProcessingErrorEntity entity,

--- a/src/Api/Data/ImportPreNotificationRepository.cs
+++ b/src/Api/Data/ImportPreNotificationRepository.cs
@@ -149,12 +149,9 @@ public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreN
     // ReSharper disable once ClassNeverInstantiated.Local
     private sealed record NotificationUpdate(string Id, DateTime Updated);
 
-    public async Task<ImportPreNotificationEntity> Insert(
-        ImportPreNotificationEntity entity,
-        CancellationToken cancellationToken
-    )
+    public ImportPreNotificationEntity Insert(ImportPreNotificationEntity entity)
     {
-        await dbContext.ImportPreNotifications.Insert(entity, cancellationToken);
+        dbContext.ImportPreNotifications.Insert(entity);
 
         return entity;
     }
@@ -173,7 +170,7 @@ public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreN
 
         entity.Created = existing.Created;
 
-        await dbContext.ImportPreNotifications.Update(entity, etag, cancellationToken);
+        dbContext.ImportPreNotifications.Update(entity, etag);
 
         return (existing, entity);
     }
@@ -186,13 +183,11 @@ public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreN
     {
         var notifications = await GetAll(customsDeclarationIdentifiers, cancellationToken);
 
-        await TrackImportPreNotificationUpdate(source, notifications, cancellationToken);
+        TrackImportPreNotificationUpdate(source, notifications);
     }
 
-    public async Task TrackImportPreNotificationUpdate(
-        ImportPreNotificationEntity entity,
-        CancellationToken cancellationToken
-    ) => await TrackImportPreNotificationUpdate(entity, [entity], cancellationToken);
+    public void TrackImportPreNotificationUpdate(ImportPreNotificationEntity entity) =>
+        TrackImportPreNotificationUpdate(entity, [entity]);
 
     public async Task<string?> GetMaxId(CancellationToken cancellationToken)
     {
@@ -205,11 +200,7 @@ public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreN
         return entity?.Id;
     }
 
-    private async Task TrackImportPreNotificationUpdate(
-        IDataEntity source,
-        List<ImportPreNotificationEntity> notifications,
-        CancellationToken cancellationToken
-    )
+    private void TrackImportPreNotificationUpdate(IDataEntity source, List<ImportPreNotificationEntity> notifications)
     {
         if (notifications.Count == 0)
             return;
@@ -227,7 +218,7 @@ public class ImportPreNotificationRepository(IDbContext dbContext) : IImportPreN
         {
             update.SetSource(source);
 
-            await dbContext.ImportPreNotificationUpdates.Insert(update, cancellationToken);
+            dbContext.ImportPreNotificationUpdates.Insert(update);
         }
     }
 }

--- a/src/Api/Data/ProcessingErrorRepository.cs
+++ b/src/Api/Data/ProcessingErrorRepository.cs
@@ -14,9 +14,9 @@ public class ProcessingErrorRepository(IDbContext dbContext) : IProcessingErrorR
         return await dbContext.ProcessingErrors.Find(id, cancellationToken);
     }
 
-    public async Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken)
+    public ProcessingErrorEntity Insert(ProcessingErrorEntity entity)
     {
-        await dbContext.ProcessingErrors.Insert(entity, cancellationToken);
+        dbContext.ProcessingErrors.Insert(entity);
 
         return entity;
     }
@@ -35,7 +35,7 @@ public class ProcessingErrorRepository(IDbContext dbContext) : IProcessingErrorR
 
         entity.Created = existing.Created;
 
-        await dbContext.ProcessingErrors.Update(entity, etag, cancellationToken);
+        dbContext.ProcessingErrors.Update(entity, etag);
 
         return (existing, entity);
     }

--- a/src/Api/Services/CustomsDeclarationService.cs
+++ b/src/Api/Services/CustomsDeclarationService.cs
@@ -24,11 +24,13 @@ public class CustomsDeclarationService(
         CancellationToken cancellationToken
     )
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var inserted = await customsDeclarationRepository.Insert(entity, cancellationToken);
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
 
         await resourceEventPublisher.Publish(
             inserted
@@ -45,6 +47,8 @@ public class CustomsDeclarationService(
                 ),
             cancellationToken
         );
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
@@ -65,11 +69,13 @@ public class CustomsDeclarationService(
         CancellationToken cancellationToken
     )
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var (existing, updated) = await customsDeclarationRepository.Update(entity, etag, cancellationToken);
 
         await TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
 
         await resourceEventPublisher.Publish(
             updated
@@ -92,6 +98,8 @@ public class CustomsDeclarationService(
                 ),
             cancellationToken
         );
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Api/Services/CustomsDeclarationService.cs
+++ b/src/Api/Services/CustomsDeclarationService.cs
@@ -26,7 +26,7 @@ public class CustomsDeclarationService(
     {
         await dbContext.StartTransaction(cancellationToken);
 
-        var inserted = await customsDeclarationRepository.Insert(entity, cancellationToken);
+        var inserted = customsDeclarationRepository.Insert(entity);
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 

--- a/src/Api/Services/DataEntityExtensions.cs
+++ b/src/Api/Services/DataEntityExtensions.cs
@@ -73,7 +73,7 @@ public static class DataEntityExtensions
 
         if (knownSubResourceTypes.Count > 1)
             throw new InvalidOperationException(
-                "Change set contains multiple known sub resource types, only one changing at a time is currently expected"
+                $"Change set contains multiple known sub resource types \"{string.Join(", ", knownSubResourceTypes)}\", only one changing at a time is currently expected"
             );
 
         return @event with

--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -35,22 +35,30 @@ public class GmrService(
 
     public async Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken)
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var inserted = await gmrRepository.Insert(entity, cancellationToken);
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
 
     public async Task<GmrEntity> Update(GmrEntity entity, string etag, CancellationToken cancellationToken)
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var (_, updated) = await gmrRepository.Update(entity, etag, cancellationToken);
 
         await TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -37,7 +37,7 @@ public class GmrService(
     {
         await dbContext.StartTransaction(cancellationToken);
 
-        var inserted = await gmrRepository.Insert(entity, cancellationToken);
+        var inserted = gmrRepository.Insert(entity);
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -36,11 +36,13 @@ public class ImportPreNotificationService(
         CancellationToken cancellationToken
     )
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var inserted = await importPreNotificationRepository.Insert(entity, cancellationToken);
 
         await importPreNotificationRepository.TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
 
         await resourceEventPublisher.Publish(
             inserted
@@ -48,6 +50,8 @@ public class ImportPreNotificationService(
                 .WithChangeSet(inserted.ImportPreNotification, new ImportPreNotification()),
             cancellationToken
         );
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
@@ -58,11 +62,13 @@ public class ImportPreNotificationService(
         CancellationToken cancellationToken
     )
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var (existing, updated) = await importPreNotificationRepository.Update(entity, etag, cancellationToken);
 
         await importPreNotificationRepository.TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
 
         await resourceEventPublisher.Publish(
             updated
@@ -70,6 +76,8 @@ public class ImportPreNotificationService(
                 .WithChangeSet(updated.ImportPreNotification, existing.ImportPreNotification),
             cancellationToken
         );
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -38,9 +38,9 @@ public class ImportPreNotificationService(
     {
         await dbContext.StartTransaction(cancellationToken);
 
-        var inserted = await importPreNotificationRepository.Insert(entity, cancellationToken);
+        var inserted = importPreNotificationRepository.Insert(entity);
 
-        await importPreNotificationRepository.TrackImportPreNotificationUpdate(inserted, cancellationToken);
+        importPreNotificationRepository.TrackImportPreNotificationUpdate(inserted);
 
         await dbContext.SaveChanges(cancellationToken);
 
@@ -66,7 +66,7 @@ public class ImportPreNotificationService(
 
         var (existing, updated) = await importPreNotificationRepository.Update(entity, etag, cancellationToken);
 
-        await importPreNotificationRepository.TrackImportPreNotificationUpdate(updated, cancellationToken);
+        importPreNotificationRepository.TrackImportPreNotificationUpdate(updated);
 
         await dbContext.SaveChanges(cancellationToken);
 

--- a/src/Api/Services/ProcessingErrorService.cs
+++ b/src/Api/Services/ProcessingErrorService.cs
@@ -19,7 +19,7 @@ public class ProcessingErrorService(
     {
         await dbContext.StartTransaction(cancellationToken);
 
-        var inserted = await processingErrorRepository.Insert(entity, cancellationToken);
+        var inserted = processingErrorRepository.Insert(entity);
 
         await dbContext.SaveChanges(cancellationToken);
 

--- a/src/Api/Services/ProcessingErrorService.cs
+++ b/src/Api/Services/ProcessingErrorService.cs
@@ -17,14 +17,18 @@ public class ProcessingErrorService(
 
     public async Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken)
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var inserted = await processingErrorRepository.Insert(entity, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
 
         await resourceEventPublisher.Publish(
             inserted.ToResourceEvent(ResourceEventOperations.Created).WithChangeSet(inserted.ProcessingErrors, []),
             cancellationToken
         );
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
@@ -35,9 +39,11 @@ public class ProcessingErrorService(
         CancellationToken cancellationToken
     )
     {
+        await dbContext.StartTransaction(cancellationToken);
+
         var (existing, updated) = await processingErrorRepository.Update(entity, etag, cancellationToken);
 
-        await dbContext.SaveChangesAsync(cancellationToken);
+        await dbContext.SaveChanges(cancellationToken);
 
         await resourceEventPublisher.Publish(
             updated
@@ -45,6 +51,8 @@ public class ProcessingErrorService(
                 .WithChangeSet(updated.ProcessingErrors, existing.ProcessingErrors),
             cancellationToken
         );
+
+        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Data/IDbContext.cs
+++ b/src/Data/IDbContext.cs
@@ -14,5 +14,9 @@ public interface IDbContext
 
     IMongoCollectionSet<ProcessingErrorEntity> ProcessingErrors { get; }
 
-    Task SaveChangesAsync(CancellationToken cancellationToken);
+    Task SaveChanges(CancellationToken cancellationToken);
+
+    Task StartTransaction(CancellationToken cancellationToken);
+
+    Task CommitTransaction(CancellationToken cancellationToken);
 }

--- a/src/Data/IMongoCollectionSet.cs
+++ b/src/Data/IMongoCollectionSet.cs
@@ -9,8 +9,6 @@ public interface IMongoCollectionSet<T> : IQueryable<T>
 {
     IMongoCollection<T> Collection { get; }
 
-    int PendingChanges { get; }
-
     Task<T?> Find(string id, CancellationToken cancellationToken = default);
 
     Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default);
@@ -25,5 +23,5 @@ public interface IMongoCollectionSet<T> : IQueryable<T>
 
     Task Update(T item, string etag, CancellationToken cancellationToken = default);
 
-    Task PersistAsync(CancellationToken cancellationToken);
+    Task Save(CancellationToken cancellationToken);
 }

--- a/src/Data/IMongoCollectionSet.cs
+++ b/src/Data/IMongoCollectionSet.cs
@@ -9,19 +9,13 @@ public interface IMongoCollectionSet<T> : IQueryable<T>
 {
     IMongoCollection<T> Collection { get; }
 
-    Task<T?> Find(string id, CancellationToken cancellationToken = default);
+    Task<T?> Find(string id, CancellationToken cancellationToken);
 
-    Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default);
+    Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken);
 
-    Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default);
+    void Insert(T item);
 
-    Task Insert(T item, CancellationToken cancellationToken = default);
-
-    Task Update(T item, CancellationToken cancellationToken = default);
-
-    Task Update(List<T> items, CancellationToken cancellationToken = default);
-
-    Task Update(T item, string etag, CancellationToken cancellationToken = default);
+    void Update(T item, string etag);
 
     Task Save(CancellationToken cancellationToken);
 }

--- a/src/Data/Mongo/MongoCollectionSet.cs
+++ b/src/Data/Mongo/MongoCollectionSet.cs
@@ -15,15 +15,9 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
 
     private IQueryable<T> EntityQueryable => Collection.AsQueryable();
 
-    public IEnumerator<T> GetEnumerator()
-    {
-        return EntityQueryable.GetEnumerator();
-    }
+    public IEnumerator<T> GetEnumerator() => EntityQueryable.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return EntityQueryable.GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => EntityQueryable.GetEnumerator();
 
     public Type ElementType => EntityQueryable.ElementType;
     public Expression Expression => EntityQueryable.Expression;
@@ -34,20 +28,11 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
             ? dbContext.Database.GetCollection<T>(typeof(T).Name.Replace("Entity", ""))
             : dbContext.Database.GetCollection<T>(collectionName);
 
-    public async Task<T?> Find(string id, CancellationToken cancellationToken = default)
-    {
-        return await EntityQueryable.SingleOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
-    }
+    public async Task<T?> Find(string id, CancellationToken cancellationToken) =>
+        await EntityQueryable.SingleOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
 
-    public async Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
-    {
-        return await EntityQueryable.FirstOrDefaultAsync(query, cancellationToken: cancellationToken);
-    }
-
-    public async Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
-    {
-        return await EntityQueryable.Where(query).ToListAsync(cancellationToken);
-    }
+    public async Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken) =>
+        await EntityQueryable.Where(query).ToListAsync(cancellationToken);
 
     public async Task Save(CancellationToken cancellationToken)
     {
@@ -107,34 +92,19 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
         }
     }
 
-    public Task Insert(T item, CancellationToken cancellationToken = default)
+    public void Insert(T item)
     {
         item.Created = item.Updated = DateTime.UtcNow;
         item.OnSave();
 
         _entitiesToInsert.Add(item);
-
-        return Task.CompletedTask;
     }
 
-    public async Task Update(T item, CancellationToken cancellationToken = default)
-    {
-        await Update(item, item.ETag, cancellationToken);
-    }
-
-    public async Task Update(List<T> items, CancellationToken cancellationToken = default)
-    {
-        foreach (var item in items)
-        {
-            await Update(item, cancellationToken);
-        }
-    }
-
-    public Task Update(T item, string etag, CancellationToken cancellationToken = default)
+    public void Update(T item, string etag)
     {
         if (_entitiesToInsert.Exists(x => x.Id == item.Id))
         {
-            return Task.CompletedTask;
+            return;
         }
 
         ArgumentNullException.ThrowIfNull(etag);
@@ -145,7 +115,5 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
         item.OnSave();
 
         _entitiesToUpdate.Add(new ValueTuple<T, string>(item, etag));
-
-        return Task.CompletedTask;
     }
 }

--- a/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
+++ b/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
@@ -69,6 +69,7 @@ public class CustomsDeclarationServiceTests
 
         await Subject.Insert(entity, CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await CustomsDeclarationRepository.Received().Insert(entity, CancellationToken.None);
         await ImportPreNotificationRepository
             .Received()
@@ -77,7 +78,7 @@ public class CustomsDeclarationServiceTests
                 Arg.Is<string[]>(x => x.SequenceEqual(entity.ImportPreNotificationIdentifiers)),
                 CancellationToken.None
             );
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -86,6 +87,7 @@ public class CustomsDeclarationServiceTests
                 ),
                 CancellationToken.None
             );
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -107,8 +109,9 @@ public class CustomsDeclarationServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await CustomsDeclarationRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -117,6 +120,7 @@ public class CustomsDeclarationServiceTests
                 ),
                 CancellationToken.None
             );
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
+++ b/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
@@ -60,8 +60,8 @@ public class CustomsDeclarationServiceTests
             },
         };
         CustomsDeclarationRepository
-            .Insert(entity, CancellationToken.None)
-            .Returns(x =>
+            .Insert(entity)
+            .Returns(_ =>
             {
                 entity.OnSave();
                 return entity;
@@ -70,7 +70,7 @@ public class CustomsDeclarationServiceTests
         await Subject.Insert(entity, CancellationToken.None);
 
         await DbContext.Received().StartTransaction(CancellationToken.None);
-        await CustomsDeclarationRepository.Received().Insert(entity, CancellationToken.None);
+        CustomsDeclarationRepository.Received().Insert(entity);
         await ImportPreNotificationRepository
             .Received()
             .TrackImportPreNotificationUpdate(

--- a/tests/Api.Tests/Services/GmrServiceTests.cs
+++ b/tests/Api.Tests/Services/GmrServiceTests.cs
@@ -114,8 +114,8 @@ public class GmrServiceTests
             Gmr = new Gmr { Declarations = new Declarations { Customs = [new Customs { Id = mrn }] } },
         };
         GmrRepository
-            .Insert(entity, CancellationToken.None)
-            .Returns(x =>
+            .Insert(entity)
+            .Returns(_ =>
             {
                 entity.OnSave();
                 return entity;
@@ -130,7 +130,7 @@ public class GmrServiceTests
         await Subject.Insert(entity, CancellationToken.None);
 
         await DbContext.Received().StartTransaction(CancellationToken.None);
-        await GmrRepository.Received().Insert(entity, CancellationToken.None);
+        GmrRepository.Received().Insert(entity);
         await ImportPreNotificationRepository
             .Received()
             .TrackImportPreNotificationUpdate(

--- a/tests/Api.Tests/Services/GmrServiceTests.cs
+++ b/tests/Api.Tests/Services/GmrServiceTests.cs
@@ -129,6 +129,7 @@ public class GmrServiceTests
 
         await Subject.Insert(entity, CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await GmrRepository.Received().Insert(entity, CancellationToken.None);
         await ImportPreNotificationRepository
             .Received()
@@ -137,7 +138,8 @@ public class GmrServiceTests
                 Arg.Is<string[]>(x => x.SequenceEqual(importPreNotificationIdentifiers)),
                 CancellationToken.None
             );
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -159,8 +161,10 @@ public class GmrServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await GmrRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -40,12 +40,12 @@ public class ImportPreNotificationServiceTests
             Id = "id",
             ImportPreNotification = new ImportPreNotification { Version = 1 },
         };
-        ImportPreNotificationRepository.Insert(entity, CancellationToken.None).Returns(entity);
+        ImportPreNotificationRepository.Insert(entity).Returns(entity);
 
         await Subject.Insert(entity, CancellationToken.None);
 
         await DbContext.Received().StartTransaction(CancellationToken.None);
-        await ImportPreNotificationRepository.Received().Insert(entity, CancellationToken.None);
+        ImportPreNotificationRepository.Received().Insert(entity);
         await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -44,8 +44,9 @@ public class ImportPreNotificationServiceTests
 
         await Subject.Insert(entity, CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await ImportPreNotificationRepository.Received().Insert(entity, CancellationToken.None);
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -54,6 +55,7 @@ public class ImportPreNotificationServiceTests
                 ),
                 CancellationToken.None
             );
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -75,8 +77,9 @@ public class ImportPreNotificationServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await ImportPreNotificationRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -85,6 +88,7 @@ public class ImportPreNotificationServiceTests
                 ),
                 CancellationToken.None
             );
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/ProcessingErrorServiceTests.cs
+++ b/tests/Api.Tests/Services/ProcessingErrorServiceTests.cs
@@ -37,14 +37,16 @@ public class ProcessingErrorServiceTests
 
         await Subject.Insert(entity, CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await ProcessingErrorRepository.Received().Insert(entity, CancellationToken.None);
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
                 Arg.Is<ResourceEvent<ProcessingErrorEntity>>(x => x.Operation == "Created" && x.ChangeSet.Count > 0),
                 CancellationToken.None
             );
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -70,14 +72,16 @@ public class ProcessingErrorServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
+        await DbContext.Received().StartTransaction(CancellationToken.None);
         await ProcessingErrorRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
+        await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
                 Arg.Is<ResourceEvent<ProcessingErrorEntity>>(x => x.Operation == "Updated" && x.ChangeSet.Count > 0),
                 CancellationToken.None
             );
+        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/ProcessingErrorServiceTests.cs
+++ b/tests/Api.Tests/Services/ProcessingErrorServiceTests.cs
@@ -33,12 +33,12 @@ public class ProcessingErrorServiceTests
             Id = "id",
             ProcessingErrors = [new ProcessingError { ExternalVersion = 1 }],
         };
-        ProcessingErrorRepository.Insert(entity, CancellationToken.None).Returns(entity);
+        ProcessingErrorRepository.Insert(entity).Returns(entity);
 
         await Subject.Insert(entity, CancellationToken.None);
 
         await DbContext.Received().StartTransaction(CancellationToken.None);
-        await ProcessingErrorRepository.Received().Insert(entity, CancellationToken.None);
+        ProcessingErrorRepository.Received().Insert(entity);
         await DbContext.Received().SaveChanges(CancellationToken.None);
         await ResourceEventPublisher
             .Received()

--- a/tests/Api.Tests/Utils/InMemoryData/MemoryCollectionSet.cs
+++ b/tests/Api.Tests/Utils/InMemoryData/MemoryCollectionSet.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
@@ -14,15 +13,9 @@ public class MemoryCollectionSet<T> : IMongoCollectionSet<T>
 
     private IQueryable<T> EntityQueryable => _data.AsQueryable();
 
-    public IEnumerator<T> GetEnumerator()
-    {
-        return _data.GetEnumerator();
-    }
+    public IEnumerator<T> GetEnumerator() => _data.GetEnumerator();
 
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
-    }
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
     public Type ElementType => EntityQueryable.ElementType;
     public Expression Expression => EntityQueryable.Expression;
@@ -30,58 +23,17 @@ public class MemoryCollectionSet<T> : IMongoCollectionSet<T>
 
     public IMongoCollection<T> Collection => throw new NotImplementedException();
 
-    internal void AddTestData(T item)
-    {
-        _data.Add(item);
-    }
+    internal void AddTestData(T item) => _data.Add(item);
 
-    public Task<T?> Find(string id, CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult(_data.Find(x => x.Id == id));
-    }
+    public Task<T?> Find(string id, CancellationToken cancellationToken) =>
+        Task.FromResult(_data.Find(x => x.Id == id));
 
-    public Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult(_data.Find(i => query.Compile()(i)));
-    }
+    public Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken) =>
+        Task.FromResult(_data.FindAll(i => query.Compile()(i)));
 
-    public Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
-    {
-        return Task.FromResult(_data.FindAll(i => query.Compile()(i)));
-    }
+    public void Insert(T item) => throw new NotImplementedException();
 
-    public Task Insert(T item, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
+    public void Update(T item, string etag) => throw new NotImplementedException();
 
-    [SuppressMessage(
-        "SonarLint",
-        "S2955",
-        Justification = "IEquatable<T> would need to be implemented on every data entity just to stop sonar complaining about a null check. Nope."
-    )]
-    public Task Update(T item, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task Update(List<T> items, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    [SuppressMessage(
-        "SonarLint",
-        "S2955",
-        Justification = "IEquatable<T> would need to be implemented on every data entity just to stop sonar complaining about a null check. Nope."
-    )]
-    public Task Update(T item, string etag, CancellationToken cancellationToken = default)
-    {
-        throw new NotImplementedException();
-    }
-
-    public Task Save(CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
+    public Task Save(CancellationToken cancellationToken) => throw new NotImplementedException();
 }

--- a/tests/Api.Tests/Utils/InMemoryData/MemoryCollectionSet.cs
+++ b/tests/Api.Tests/Utils/InMemoryData/MemoryCollectionSet.cs
@@ -29,7 +29,6 @@ public class MemoryCollectionSet<T> : IMongoCollectionSet<T>
     public IQueryProvider Provider => EntityQueryable.Provider;
 
     public IMongoCollection<T> Collection => throw new NotImplementedException();
-    public int PendingChanges => 0;
 
     internal void AddTestData(T item)
     {
@@ -81,7 +80,7 @@ public class MemoryCollectionSet<T> : IMongoCollectionSet<T>
         throw new NotImplementedException();
     }
 
-    public Task PersistAsync(CancellationToken cancellationToken)
+    public Task Save(CancellationToken cancellationToken)
     {
         throw new NotImplementedException();
     }

--- a/tests/Api.Tests/Utils/InMemoryData/MemoryDbContext.cs
+++ b/tests/Api.Tests/Utils/InMemoryData/MemoryDbContext.cs
@@ -19,8 +19,9 @@ public class MemoryDbContext : IDbContext
     public IMongoCollectionSet<ProcessingErrorEntity> ProcessingErrors { get; } =
         new MemoryCollectionSet<ProcessingErrorEntity>();
 
-    public Task SaveChangesAsync(CancellationToken cancellationToken)
-    {
-        throw new NotImplementedException();
-    }
+    public Task SaveChanges(CancellationToken cancellationToken) => throw new NotImplementedException();
+
+    public Task StartTransaction(CancellationToken cancellationToken) => throw new NotImplementedException();
+
+    public Task CommitTransaction(CancellationToken cancellationToken) => throw new NotImplementedException();
 }


### PR DESCRIPTION
In order to protect the state of our data, we are now prohibiting persistence if the write to SNS does not succeed.

Now the behaviour risk is flipped as we might experience a failure to commit a transaction after the SNS write has taken place OR the event could be consumed before the transaction has written.

The latter should be unlikely as the default transaction isolation is read uncommitted. We save first and then we write to SNS, so data will be written on save. Should the SNS write fail, the transaction will not be committed but we might have had reads during the period between save and SNS failure. Do we care?

We could look at changing the transaction isolation level to prevent dirty reads but we move more towards consuming before data is committed. Which in turn moves us more towards needing an outbox pattern approach. 

Do we want to implement this now or is what is in this PR deemed sufficient, and better than what is there today based on the behaviour we have seen?

Would like to discuss please.

--

Also included in this PR is removal of unused data layer methods and conversion of methods that were pretending to be async when in reality they were note.

This means there is less code to maintain and method signatures now match the true inner implementation without indirectly creating any asynchronous state machines.