### PR TITLE
CDMS-917: Reduce output during Dockerfile build to avoid Github actions build step hanging

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           docker compose logs
       - name: Check Dockerfile Builds
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           docker compose logs
       - name: Check Dockerfile Builds
-        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN echo "OpenAPI file generated successfully ($(wc -l < openapi.json) lines, $(
 RUN head -n 10 openapi.json
 RUN echo "... (file truncated for display) ..."
 RUN tail -n 10 openapi.json
+RUN timeout 10s cat openapi.json || echo "cat timed out"
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ RUN dotnet build src/Api/Api.csproj --no-restore -c Release
 
 COPY src/Api/appsettings.json .
 RUN dotnet swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.TradeImportsDataApi.Api.dll v1
+RUN cat openapi.json
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update && \
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
-ARG VACUUM_VERSION=0.14.2
+ARG VACUUM_VERSION=0.17.6
 WORKDIR /tmp/vacuum
 RUN wget --secure-protocol=TLSv1_2 "https://github.com/daveshanley/vacuum/releases/download/v${VACUUM_VERSION}/vacuum_${VACUUM_VERSION}_linux_x86_64.tar.gz" -q -O vacuum.tar.gz && \
     tar zxvf "vacuum.tar.gz" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN lsof openapi.json 2>/dev/null || echo "No file locks found"
 RUN echo "=== File content check ==="
 RUN timeout 10s head -n 5 openapi.json || echo "Cannot read file or timeout"
 RUN echo "=== End diagnostics ==="
+RUN cat openapi.json
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,15 @@ RUN dotnet build src/Api/Api.csproj --no-restore -c Release
 
 COPY src/Api/appsettings.json .
 RUN dotnet swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.TradeImportsDataApi.Api.dll v1
-RUN cat openapi.json
+RUN echo "=== File system check ==="
+RUN ls -la openapi.json || echo "File does not exist"
+RUN echo "=== Process check ==="
+RUN ps aux | grep -v grep | grep -E "(dotnet|swagger)" || echo "No relevant processes"
+RUN echo "=== File lock check ==="
+RUN lsof openapi.json 2>/dev/null || echo "No file locks found"
+RUN echo "=== File content check ==="
+RUN timeout 10s head -n 5 openapi.json || echo "Cannot read file or timeout"
+RUN echo "=== End diagnostics ==="
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,20 +60,6 @@ RUN dotnet build src/Api/Api.csproj --no-restore -c Release
 
 COPY src/Api/appsettings.json .
 RUN dotnet swagger tofile --output openapi.json ./src/Api/bin/Release/net9.0/Defra.TradeImportsDataApi.Api.dll v1
-RUN echo "=== File system check ==="
-RUN ls -la openapi.json || echo "File does not exist"
-RUN echo "=== Process check ==="
-RUN ps aux | grep -v grep | grep -E "(dotnet|swagger)" || echo "No relevant processes"
-RUN echo "=== File lock check ==="
-RUN lsof openapi.json 2>/dev/null || echo "No file locks found"
-RUN echo "=== File content check ==="
-RUN timeout 10s head -n 5 openapi.json || echo "Cannot read file or timeout"
-RUN echo "=== End diagnostics ==="
-RUN ls -lh openapi.json
-RUN echo "OpenAPI file generated successfully ($(wc -l < openapi.json) lines, $(wc -c < openapi.json) bytes)"
-RUN head -n 10 openapi.json
-RUN echo "... (file truncated for display) ..."
-RUN tail -n 10 openapi.json
 RUN vacuum lint -e -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,8 +74,7 @@ RUN echo "OpenAPI file generated successfully ($(wc -l < openapi.json) lines, $(
 RUN head -n 10 openapi.json
 RUN echo "... (file truncated for display) ..."
 RUN tail -n 10 openapi.json
-RUN timeout 10s cat openapi.json || echo "cat timed out"
-RUN vacuum lint -d -r .vacuum.yml openapi.json
+RUN vacuum lint -e -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,11 @@ RUN lsof openapi.json 2>/dev/null || echo "No file locks found"
 RUN echo "=== File content check ==="
 RUN timeout 10s head -n 5 openapi.json || echo "Cannot read file or timeout"
 RUN echo "=== End diagnostics ==="
-RUN cat openapi.json
+RUN ls -lh openapi.json
+RUN echo "OpenAPI file generated successfully ($(wc -l < openapi.json) lines, $(wc -c < openapi.json) bytes)"
+RUN head -n 10 openapi.json
+RUN echo "... (file truncated for display) ..."
+RUN tail -n 10 openapi.json
 RUN vacuum lint -d -r .vacuum.yml openapi.json
 
 RUN dotnet test --no-restore --filter "Category!=IntegrationTest"

--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="8.1.4" />
     <PackageReference Include="JsonPath.Net" Version="2.1.1" />
     <PackageReference Include="JsonPatch.Net" Version="3.3.0" />
   </ItemGroup>

--- a/tests/Api.Tests/OpenApi/OpenApiTests.Redoc_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.Redoc_VerifyAsExpected.verified.txt
@@ -19,7 +19,7 @@
     },
     {
       ETag: [
-        W/"s/7yFJ69eDl0FoFWeOg6AUJVF24="
+        W/"rlT/4CizOsJwBJTgHaX7P/9PuSY="
       ]
     }
   ],


### PR DESCRIPTION
As per PR title.

~Have been seeing builds hanging over last couple of days in what seems to always be Vacuum. Therefore, trying the latest version.~

The Dockerfile build output was hanging around the Vacuum step, therefore initially thought it was something there. Updated Vacuum version, Swashbuckle for openapi.json generation and associated snapshot test.

In the end it looked like the Github actions stdout out limit was being met resulting in the build step hanging and not just truncating the log as it has been seen to do in the past. Therefore, we now run Vacuum without full details and just report on errors.

This problem is a bit of worry longer term but for now we can get past it.