### PR TITLE
Revert "CDMS-917: Ensure data is not persisted if the resource event for certain entities cannot be written to SNS"

### DIFF
--- a/src/Api/Data/CustomsDeclarationRepository.cs
+++ b/src/Api/Data/CustomsDeclarationRepository.cs
@@ -82,9 +82,12 @@ public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclar
             .ToListAsync(cancellationToken);
     }
 
-    public CustomsDeclarationEntity Insert(CustomsDeclarationEntity entity)
+    public async Task<CustomsDeclarationEntity> Insert(
+        CustomsDeclarationEntity entity,
+        CancellationToken cancellationToken
+    )
     {
-        dbContext.CustomsDeclarations.Insert(entity);
+        await dbContext.CustomsDeclarations.Insert(entity, cancellationToken);
 
         return entity;
     }
@@ -103,7 +106,7 @@ public class CustomsDeclarationRepository(IDbContext dbContext) : ICustomsDeclar
 
         entity.Created = existing.Created;
 
-        dbContext.CustomsDeclarations.Update(entity, etag);
+        await dbContext.CustomsDeclarations.Update(entity, etag, cancellationToken);
 
         return (existing, entity);
     }

--- a/src/Api/Data/GmrRepository.cs
+++ b/src/Api/Data/GmrRepository.cs
@@ -25,9 +25,9 @@ public class GmrRepository(IDbContext dbContext) : IGmrRepository
         );
     }
 
-    public GmrEntity Insert(GmrEntity entity)
+    public async Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken)
     {
-        dbContext.Gmrs.Insert(entity);
+        await dbContext.Gmrs.Insert(entity, cancellationToken);
 
         return entity;
     }
@@ -46,7 +46,7 @@ public class GmrRepository(IDbContext dbContext) : IGmrRepository
 
         entity.Created = existing.Created;
 
-        dbContext.Gmrs.Update(entity, etag);
+        await dbContext.Gmrs.Update(entity, etag, cancellationToken);
 
         return (existing, entity);
     }

--- a/src/Api/Data/ICustomsDeclarationRepository.cs
+++ b/src/Api/Data/ICustomsDeclarationRepository.cs
@@ -23,7 +23,7 @@ public interface ICustomsDeclarationRepository
 
     Task<List<string>> GetAllImportPreNotificationIdentifiers(string[] ids, CancellationToken cancellationToken);
 
-    CustomsDeclarationEntity Insert(CustomsDeclarationEntity entity);
+    Task<CustomsDeclarationEntity> Insert(CustomsDeclarationEntity entity, CancellationToken cancellationToken);
 
     Task<(CustomsDeclarationEntity Existing, CustomsDeclarationEntity Updated)> Update(
         CustomsDeclarationEntity entity,

--- a/src/Api/Data/IGmrRepository.cs
+++ b/src/Api/Data/IGmrRepository.cs
@@ -8,7 +8,7 @@ public interface IGmrRepository
 
     Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken);
 
-    GmrEntity Insert(GmrEntity entity);
+    Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken);
 
     Task<(GmrEntity Existing, GmrEntity Updated)> Update(
         GmrEntity entity,

--- a/src/Api/Data/IImportPreNotificationRepository.cs
+++ b/src/Api/Data/IImportPreNotificationRepository.cs
@@ -29,7 +29,7 @@ public interface IImportPreNotificationRepository
         CancellationToken cancellationToken = default
     );
 
-    ImportPreNotificationEntity Insert(ImportPreNotificationEntity entity);
+    Task<ImportPreNotificationEntity> Insert(ImportPreNotificationEntity entity, CancellationToken cancellationToken);
 
     Task<(ImportPreNotificationEntity Existing, ImportPreNotificationEntity Updated)> Update(
         ImportPreNotificationEntity entity,
@@ -43,7 +43,7 @@ public interface IImportPreNotificationRepository
         CancellationToken cancellationToken
     );
 
-    void TrackImportPreNotificationUpdate(ImportPreNotificationEntity entity);
+    Task TrackImportPreNotificationUpdate(ImportPreNotificationEntity entity, CancellationToken cancellationToken);
 
     Task<string?> GetMaxId(CancellationToken cancellationToken);
 }

--- a/src/Api/Data/IProcessingErrorRepository.cs
+++ b/src/Api/Data/IProcessingErrorRepository.cs
@@ -6,7 +6,7 @@ public interface IProcessingErrorRepository
 {
     Task<ProcessingErrorEntity?> Get(string id, CancellationToken cancellationToken);
 
-    ProcessingErrorEntity Insert(ProcessingErrorEntity entity);
+    Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken);
 
     Task<(ProcessingErrorEntity Existing, ProcessingErrorEntity Updated)> Update(
         ProcessingErrorEntity entity,

--- a/src/Api/Data/ProcessingErrorRepository.cs
+++ b/src/Api/Data/ProcessingErrorRepository.cs
@@ -14,9 +14,9 @@ public class ProcessingErrorRepository(IDbContext dbContext) : IProcessingErrorR
         return await dbContext.ProcessingErrors.Find(id, cancellationToken);
     }
 
-    public ProcessingErrorEntity Insert(ProcessingErrorEntity entity)
+    public async Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken)
     {
-        dbContext.ProcessingErrors.Insert(entity);
+        await dbContext.ProcessingErrors.Insert(entity, cancellationToken);
 
         return entity;
     }
@@ -35,7 +35,7 @@ public class ProcessingErrorRepository(IDbContext dbContext) : IProcessingErrorR
 
         entity.Created = existing.Created;
 
-        dbContext.ProcessingErrors.Update(entity, etag);
+        await dbContext.ProcessingErrors.Update(entity, etag, cancellationToken);
 
         return (existing, entity);
     }

--- a/src/Api/Services/CustomsDeclarationService.cs
+++ b/src/Api/Services/CustomsDeclarationService.cs
@@ -24,13 +24,11 @@ public class CustomsDeclarationService(
         CancellationToken cancellationToken
     )
     {
-        await dbContext.StartTransaction(cancellationToken);
-
-        var inserted = customsDeclarationRepository.Insert(entity);
+        var inserted = await customsDeclarationRepository.Insert(entity, cancellationToken);
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        await dbContext.SaveChanges(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         await resourceEventPublisher.Publish(
             inserted
@@ -47,8 +45,6 @@ public class CustomsDeclarationService(
                 ),
             cancellationToken
         );
-
-        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
@@ -69,13 +65,11 @@ public class CustomsDeclarationService(
         CancellationToken cancellationToken
     )
     {
-        await dbContext.StartTransaction(cancellationToken);
-
         var (existing, updated) = await customsDeclarationRepository.Update(entity, etag, cancellationToken);
 
         await TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        await dbContext.SaveChanges(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         await resourceEventPublisher.Publish(
             updated
@@ -98,8 +92,6 @@ public class CustomsDeclarationService(
                 ),
             cancellationToken
         );
-
-        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Api/Services/DataEntityExtensions.cs
+++ b/src/Api/Services/DataEntityExtensions.cs
@@ -73,7 +73,7 @@ public static class DataEntityExtensions
 
         if (knownSubResourceTypes.Count > 1)
             throw new InvalidOperationException(
-                $"Change set contains multiple known sub resource types \"{string.Join(", ", knownSubResourceTypes)}\", only one changing at a time is currently expected"
+                "Change set contains multiple known sub resource types, only one changing at a time is currently expected"
             );
 
         return @event with

--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -35,30 +35,22 @@ public class GmrService(
 
     public async Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken)
     {
-        await dbContext.StartTransaction(cancellationToken);
-
-        var inserted = gmrRepository.Insert(entity);
+        var inserted = await gmrRepository.Insert(entity, cancellationToken);
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        await dbContext.SaveChanges(cancellationToken);
-
-        await dbContext.CommitTransaction(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return inserted;
     }
 
     public async Task<GmrEntity> Update(GmrEntity entity, string etag, CancellationToken cancellationToken)
     {
-        await dbContext.StartTransaction(cancellationToken);
-
         var (_, updated) = await gmrRepository.Update(entity, etag, cancellationToken);
 
         await TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        await dbContext.SaveChanges(cancellationToken);
-
-        await dbContext.CommitTransaction(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         return updated;
     }

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -36,13 +36,11 @@ public class ImportPreNotificationService(
         CancellationToken cancellationToken
     )
     {
-        await dbContext.StartTransaction(cancellationToken);
+        var inserted = await importPreNotificationRepository.Insert(entity, cancellationToken);
 
-        var inserted = importPreNotificationRepository.Insert(entity);
+        await importPreNotificationRepository.TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        importPreNotificationRepository.TrackImportPreNotificationUpdate(inserted);
-
-        await dbContext.SaveChanges(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         await resourceEventPublisher.Publish(
             inserted
@@ -50,8 +48,6 @@ public class ImportPreNotificationService(
                 .WithChangeSet(inserted.ImportPreNotification, new ImportPreNotification()),
             cancellationToken
         );
-
-        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
@@ -62,13 +58,11 @@ public class ImportPreNotificationService(
         CancellationToken cancellationToken
     )
     {
-        await dbContext.StartTransaction(cancellationToken);
-
         var (existing, updated) = await importPreNotificationRepository.Update(entity, etag, cancellationToken);
 
-        importPreNotificationRepository.TrackImportPreNotificationUpdate(updated);
+        await importPreNotificationRepository.TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        await dbContext.SaveChanges(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         await resourceEventPublisher.Publish(
             updated
@@ -76,8 +70,6 @@ public class ImportPreNotificationService(
                 .WithChangeSet(updated.ImportPreNotification, existing.ImportPreNotification),
             cancellationToken
         );
-
-        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Api/Services/ProcessingErrorService.cs
+++ b/src/Api/Services/ProcessingErrorService.cs
@@ -17,18 +17,14 @@ public class ProcessingErrorService(
 
     public async Task<ProcessingErrorEntity> Insert(ProcessingErrorEntity entity, CancellationToken cancellationToken)
     {
-        await dbContext.StartTransaction(cancellationToken);
+        var inserted = await processingErrorRepository.Insert(entity, cancellationToken);
 
-        var inserted = processingErrorRepository.Insert(entity);
-
-        await dbContext.SaveChanges(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         await resourceEventPublisher.Publish(
             inserted.ToResourceEvent(ResourceEventOperations.Created).WithChangeSet(inserted.ProcessingErrors, []),
             cancellationToken
         );
-
-        await dbContext.CommitTransaction(cancellationToken);
 
         return inserted;
     }
@@ -39,11 +35,9 @@ public class ProcessingErrorService(
         CancellationToken cancellationToken
     )
     {
-        await dbContext.StartTransaction(cancellationToken);
-
         var (existing, updated) = await processingErrorRepository.Update(entity, etag, cancellationToken);
 
-        await dbContext.SaveChanges(cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
 
         await resourceEventPublisher.Publish(
             updated
@@ -51,8 +45,6 @@ public class ProcessingErrorService(
                 .WithChangeSet(updated.ProcessingErrors, existing.ProcessingErrors),
             cancellationToken
         );
-
-        await dbContext.CommitTransaction(cancellationToken);
 
         return updated;
     }

--- a/src/Data/IDbContext.cs
+++ b/src/Data/IDbContext.cs
@@ -14,9 +14,5 @@ public interface IDbContext
 
     IMongoCollectionSet<ProcessingErrorEntity> ProcessingErrors { get; }
 
-    Task SaveChanges(CancellationToken cancellationToken);
-
-    Task StartTransaction(CancellationToken cancellationToken);
-
-    Task CommitTransaction(CancellationToken cancellationToken);
+    Task SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Data/IMongoCollectionSet.cs
+++ b/src/Data/IMongoCollectionSet.cs
@@ -9,13 +9,21 @@ public interface IMongoCollectionSet<T> : IQueryable<T>
 {
     IMongoCollection<T> Collection { get; }
 
-    Task<T?> Find(string id, CancellationToken cancellationToken);
+    int PendingChanges { get; }
 
-    Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken);
+    Task<T?> Find(string id, CancellationToken cancellationToken = default);
 
-    void Insert(T item);
+    Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default);
 
-    void Update(T item, string etag);
+    Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default);
 
-    Task Save(CancellationToken cancellationToken);
+    Task Insert(T item, CancellationToken cancellationToken = default);
+
+    Task Update(T item, CancellationToken cancellationToken = default);
+
+    Task Update(List<T> items, CancellationToken cancellationToken = default);
+
+    Task Update(T item, string etag, CancellationToken cancellationToken = default);
+
+    Task PersistAsync(CancellationToken cancellationToken);
 }

--- a/src/Data/Mongo/MongoCollectionSet.cs
+++ b/src/Data/Mongo/MongoCollectionSet.cs
@@ -15,9 +15,15 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
 
     private IQueryable<T> EntityQueryable => Collection.AsQueryable();
 
-    public IEnumerator<T> GetEnumerator() => EntityQueryable.GetEnumerator();
+    public IEnumerator<T> GetEnumerator()
+    {
+        return EntityQueryable.GetEnumerator();
+    }
 
-    IEnumerator IEnumerable.GetEnumerator() => EntityQueryable.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return EntityQueryable.GetEnumerator();
+    }
 
     public Type ElementType => EntityQueryable.ElementType;
     public Expression Expression => EntityQueryable.Expression;
@@ -28,83 +34,108 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
             ? dbContext.Database.GetCollection<T>(typeof(T).Name.Replace("Entity", ""))
             : dbContext.Database.GetCollection<T>(collectionName);
 
-    public async Task<T?> Find(string id, CancellationToken cancellationToken) =>
-        await EntityQueryable.SingleOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
+    public int PendingChanges => _entitiesToInsert.Count + _entitiesToUpdate.Count;
 
-    public async Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken) =>
-        await EntityQueryable.Where(query).ToListAsync(cancellationToken);
-
-    public async Task Save(CancellationToken cancellationToken)
+    public async Task<T?> Find(string id, CancellationToken cancellationToken = default)
     {
-        await Insert(cancellationToken);
-        await Update(cancellationToken);
+        return await EntityQueryable.SingleOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
     }
 
-    private async Task Update(CancellationToken cancellationToken)
+    public async Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
+    {
+        return await EntityQueryable.FirstOrDefaultAsync(query, cancellationToken: cancellationToken);
+    }
+
+    public async Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
+    {
+        return await EntityQueryable.Where(query).ToListAsync(cancellationToken);
+    }
+
+    public async Task PersistAsync(CancellationToken cancellationToken)
+    {
+        await InsertDocuments(cancellationToken);
+
+        await UpdateDocuments(cancellationToken);
+    }
+
+    private async Task UpdateDocuments(CancellationToken cancellationToken)
     {
         var builder = Builders<T>.Filter;
 
         if (_entitiesToUpdate.Count != 0)
         {
-            if (dbContext.ActiveTransaction is null)
-                throw new InvalidOperationException("Transaction has not been started");
-
             foreach (var item in _entitiesToUpdate)
             {
                 var filter = builder.Eq(x => x.Id, item.Item.Id) & builder.Eq(x => x.ETag, item.Etag);
 
                 item.Item.ETag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
 
-                var updateResult = await Collection.ReplaceOneAsync(
-                    dbContext.ActiveTransaction.Session,
-                    filter,
-                    item.Item,
-                    cancellationToken: cancellationToken
-                );
+                var session = dbContext.ActiveTransaction?.Session;
+                var updateResult = session is not null
+                    ? await Collection.ReplaceOneAsync(session, filter, item.Item, cancellationToken: cancellationToken)
+                    : await Collection.ReplaceOneAsync(filter, item.Item, cancellationToken: cancellationToken);
 
                 if (updateResult.ModifiedCount == 0)
-                    throw new ConcurrencyException(item.Item.Id, item.Etag);
+                {
+                    throw new ConcurrencyException(item.Item.Id!, item.Etag);
+                }
             }
 
             _entitiesToUpdate.Clear();
         }
     }
 
-    private async Task Insert(CancellationToken cancellationToken)
+    private async Task InsertDocuments(CancellationToken cancellationToken)
     {
         if (_entitiesToInsert.Count != 0)
         {
-            if (dbContext.ActiveTransaction is null)
-                throw new InvalidOperationException("Transaction has not been started");
-
             foreach (var item in _entitiesToInsert)
             {
                 item.ETag = BsonObjectIdGenerator.Instance.GenerateId(null, null).ToString()!;
 
-                await Collection.InsertOneAsync(
-                    dbContext.ActiveTransaction.Session,
-                    item,
-                    cancellationToken: cancellationToken
-                );
+                var session = dbContext.ActiveTransaction?.Session;
+                if (session is not null)
+                {
+                    await Collection.InsertOneAsync(session, item, cancellationToken: cancellationToken);
+                }
+                else
+                {
+                    await Collection.InsertOneAsync(item, cancellationToken: cancellationToken);
+                }
             }
 
             _entitiesToInsert.Clear();
         }
     }
 
-    public void Insert(T item)
+    public Task Insert(T item, CancellationToken cancellationToken = default)
     {
         item.Created = item.Updated = DateTime.UtcNow;
         item.OnSave();
 
         _entitiesToInsert.Add(item);
+
+        return Task.CompletedTask;
     }
 
-    public void Update(T item, string etag)
+    public async Task Update(T item, CancellationToken cancellationToken = default)
+    {
+        await Update(item, item.ETag, cancellationToken);
+    }
+
+    public async Task Update(List<T> items, CancellationToken cancellationToken = default)
+    {
+        foreach (var item in items)
+        {
+            await Update(item, cancellationToken);
+        }
+    }
+
+    public Task Update(T item, string etag, CancellationToken cancellationToken = default)
     {
         if (_entitiesToInsert.Exists(x => x.Id == item.Id))
         {
-            return;
+            return Task.CompletedTask;
         }
 
         ArgumentNullException.ThrowIfNull(etag);
@@ -115,5 +146,7 @@ public class MongoCollectionSet<T>(MongoDbContext dbContext, string collectionNa
         item.OnSave();
 
         _entitiesToUpdate.Add(new ValueTuple<T, string>(item, etag));
+
+        return Task.CompletedTask;
     }
 }

--- a/src/Data/Mongo/MongoDbContext.cs
+++ b/src/Data/Mongo/MongoDbContext.cs
@@ -13,7 +13,6 @@ public class MongoDbContext : IDbContext
     public MongoDbContext(IMongoDatabase database, ILogger<MongoDbContext> logger)
     {
         _logger = logger;
-
         Database = database;
         ImportPreNotifications = new MongoCollectionSet<ImportPreNotificationEntity>(this);
         ImportPreNotificationUpdates = new MongoCollectionSet<ImportPreNotificationUpdateEntity>(this);
@@ -31,35 +30,64 @@ public class MongoDbContext : IDbContext
     public IMongoCollectionSet<GmrEntity> Gmrs { get; }
     public IMongoCollectionSet<ProcessingErrorEntity> ProcessingErrors { get; }
 
-    public async Task StartTransaction(CancellationToken cancellationToken)
+    private async Task<IDbTransaction> StartTransaction(CancellationToken cancellationToken)
     {
         var session = await Database.Client.StartSessionAsync(cancellationToken: cancellationToken);
         session.StartTransaction();
 
         ActiveTransaction = new MongoDbTransaction(session);
+
+        return ActiveTransaction;
     }
 
-    public async Task CommitTransaction(CancellationToken cancellationToken)
+    public async Task SaveChangesAsync(CancellationToken cancellationToken)
     {
-        if (ActiveTransaction is null)
-            throw new InvalidOperationException("No active transaction");
-
-        await ActiveTransaction.Commit(cancellationToken);
-
-        ActiveTransaction = null;
+        switch (GetChangedRecordsCount())
+        {
+            case 0:
+                return;
+            case 1:
+                await SaveChanges(cancellationToken);
+                break;
+            default:
+                await SaveChangesWithinTransaction(cancellationToken);
+                break;
+        }
     }
 
-    public async Task SaveChanges(CancellationToken cancellationToken)
+    private async Task SaveChangesWithinTransaction(CancellationToken cancellationToken)
+    {
+        using var transaction = await StartTransaction(cancellationToken);
+
+        await SaveChanges(cancellationToken);
+
+        // If the transaction is not committed within the using scope,
+        // then it will be rolled back automatically by the transaction
+        await transaction.Commit(cancellationToken);
+    }
+
+    private int GetChangedRecordsCount()
+    {
+        // This logic needs to be reviewed as it's easy to forget to include any new collection sets
+        return ImportPreNotifications.PendingChanges
+            + ImportPreNotificationUpdates.PendingChanges
+            + CustomsDeclarations.PendingChanges
+            + Gmrs.PendingChanges
+            + ProcessingErrors.PendingChanges;
+    }
+
+    private async Task SaveChanges(CancellationToken cancellationToken)
     {
         try
         {
-            await ImportPreNotifications.Save(cancellationToken);
-            await CustomsDeclarations.Save(cancellationToken);
-            await Gmrs.Save(cancellationToken);
-            await ProcessingErrors.Save(cancellationToken);
+            // This logic needs to be reviewed as it's easy to forget to include any new collection sets
+            await ImportPreNotifications.PersistAsync(cancellationToken);
+            await CustomsDeclarations.PersistAsync(cancellationToken);
+            await Gmrs.PersistAsync(cancellationToken);
+            await ProcessingErrors.PersistAsync(cancellationToken);
 
             // Keep this last as upserts above will impact those below
-            await ImportPreNotificationUpdates.Save(cancellationToken);
+            await ImportPreNotificationUpdates.PersistAsync(cancellationToken);
         }
         catch (MongoCommandException mongoCommandException) when (mongoCommandException.Code == 112)
         {

--- a/tests/Api.IntegrationTests/Endpoints/CustomsDeclarationTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/CustomsDeclarationTests.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using Defra.TradeImportsDataApi.Testing;
@@ -127,54 +126,5 @@ public class CustomsDeclarationTests(ITestOutputHelper testOutputHelper) : SqsTe
         Assert.True(
             await AsyncWaiter.WaitForAsync(async () => (await GetQueueAttributes()).ApproximateNumberOfMessages == 1)
         );
-    }
-
-    [Fact]
-    public async Task WhenWritingTwoSubResourceProperties_ShouldNotChangeDbState()
-    {
-        var client = CreateDataApiClient();
-        var mrn = Guid.NewGuid().ToString("N");
-        const int version = 1;
-
-        var result = await client.GetCustomsDeclaration(mrn, CancellationToken.None);
-        result.Should().BeNull();
-
-        await client.PutCustomsDeclaration(
-            mrn,
-            new CustomsDeclaration { ClearanceRequest = new ClearanceRequest { ExternalVersion = version } },
-            null,
-            CancellationToken.None
-        );
-
-        result = await client.GetCustomsDeclaration(mrn, CancellationToken.None);
-        result.Should().NotBeNull();
-        result.ClearanceRequest?.ExternalVersion.Should().Be(version);
-
-        HttpRequestException? exception = null;
-
-        try
-        {
-            await client.PutCustomsDeclaration(
-                mrn,
-                new CustomsDeclaration
-                {
-                    ClearanceRequest = new ClearanceRequest { ExternalVersion = 2 },
-                    ClearanceDecision = new ClearanceDecision { Items = [] },
-                },
-                result.ETag,
-                CancellationToken.None
-            );
-        }
-        catch (HttpRequestException ex)
-        {
-            exception = ex;
-        }
-
-        exception.Should().NotBeNull();
-        exception.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-
-        var result2 = await client.GetCustomsDeclaration(mrn, CancellationToken.None);
-        result2.Should().NotBeNull();
-        result2.ClearanceRequest?.ExternalVersion.Should().Be(version);
     }
 }

--- a/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
+++ b/tests/Api.Tests/Services/CustomsDeclarationServiceTests.cs
@@ -60,8 +60,8 @@ public class CustomsDeclarationServiceTests
             },
         };
         CustomsDeclarationRepository
-            .Insert(entity)
-            .Returns(_ =>
+            .Insert(entity, CancellationToken.None)
+            .Returns(x =>
             {
                 entity.OnSave();
                 return entity;
@@ -69,8 +69,7 @@ public class CustomsDeclarationServiceTests
 
         await Subject.Insert(entity, CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
-        CustomsDeclarationRepository.Received().Insert(entity);
+        await CustomsDeclarationRepository.Received().Insert(entity, CancellationToken.None);
         await ImportPreNotificationRepository
             .Received()
             .TrackImportPreNotificationUpdate(
@@ -78,7 +77,7 @@ public class CustomsDeclarationServiceTests
                 Arg.Is<string[]>(x => x.SequenceEqual(entity.ImportPreNotificationIdentifiers)),
                 CancellationToken.None
             );
-        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -87,7 +86,6 @@ public class CustomsDeclarationServiceTests
                 ),
                 CancellationToken.None
             );
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -109,9 +107,8 @@ public class CustomsDeclarationServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
         await CustomsDeclarationRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -120,7 +117,6 @@ public class CustomsDeclarationServiceTests
                 ),
                 CancellationToken.None
             );
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/GmrServiceTests.cs
+++ b/tests/Api.Tests/Services/GmrServiceTests.cs
@@ -114,8 +114,8 @@ public class GmrServiceTests
             Gmr = new Gmr { Declarations = new Declarations { Customs = [new Customs { Id = mrn }] } },
         };
         GmrRepository
-            .Insert(entity)
-            .Returns(_ =>
+            .Insert(entity, CancellationToken.None)
+            .Returns(x =>
             {
                 entity.OnSave();
                 return entity;
@@ -129,8 +129,7 @@ public class GmrServiceTests
 
         await Subject.Insert(entity, CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
-        GmrRepository.Received().Insert(entity);
+        await GmrRepository.Received().Insert(entity, CancellationToken.None);
         await ImportPreNotificationRepository
             .Received()
             .TrackImportPreNotificationUpdate(
@@ -138,8 +137,7 @@ public class GmrServiceTests
                 Arg.Is<string[]>(x => x.SequenceEqual(importPreNotificationIdentifiers)),
                 CancellationToken.None
             );
-        await DbContext.Received().SaveChanges(CancellationToken.None);
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
     }
 
     [Fact]
@@ -161,10 +159,8 @@ public class GmrServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
         await GmrRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChanges(CancellationToken.None);
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
+++ b/tests/Api.Tests/Services/ImportPreNotificationServiceTests.cs
@@ -40,13 +40,12 @@ public class ImportPreNotificationServiceTests
             Id = "id",
             ImportPreNotification = new ImportPreNotification { Version = 1 },
         };
-        ImportPreNotificationRepository.Insert(entity).Returns(entity);
+        ImportPreNotificationRepository.Insert(entity, CancellationToken.None).Returns(entity);
 
         await Subject.Insert(entity, CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
-        ImportPreNotificationRepository.Received().Insert(entity);
-        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await ImportPreNotificationRepository.Received().Insert(entity, CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -55,7 +54,6 @@ public class ImportPreNotificationServiceTests
                 ),
                 CancellationToken.None
             );
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -77,9 +75,8 @@ public class ImportPreNotificationServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
         await ImportPreNotificationRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
@@ -88,7 +85,6 @@ public class ImportPreNotificationServiceTests
                 ),
                 CancellationToken.None
             );
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Services/ProcessingErrorServiceTests.cs
+++ b/tests/Api.Tests/Services/ProcessingErrorServiceTests.cs
@@ -33,20 +33,18 @@ public class ProcessingErrorServiceTests
             Id = "id",
             ProcessingErrors = [new ProcessingError { ExternalVersion = 1 }],
         };
-        ProcessingErrorRepository.Insert(entity).Returns(entity);
+        ProcessingErrorRepository.Insert(entity, CancellationToken.None).Returns(entity);
 
         await Subject.Insert(entity, CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
-        ProcessingErrorRepository.Received().Insert(entity);
-        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await ProcessingErrorRepository.Received().Insert(entity, CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
                 Arg.Is<ResourceEvent<ProcessingErrorEntity>>(x => x.Operation == "Created" && x.ChangeSet.Count > 0),
                 CancellationToken.None
             );
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -72,16 +70,14 @@ public class ProcessingErrorServiceTests
 
         await Subject.Update(entity, "etag", CancellationToken.None);
 
-        await DbContext.Received().StartTransaction(CancellationToken.None);
         await ProcessingErrorRepository.Received().Update(entity, "etag", CancellationToken.None);
-        await DbContext.Received().SaveChanges(CancellationToken.None);
+        await DbContext.Received().SaveChangesAsync(CancellationToken.None);
         await ResourceEventPublisher
             .Received()
             .Publish(
                 Arg.Is<ResourceEvent<ProcessingErrorEntity>>(x => x.Operation == "Updated" && x.ChangeSet.Count > 0),
                 CancellationToken.None
             );
-        await DbContext.Received().CommitTransaction(CancellationToken.None);
     }
 
     [Fact]

--- a/tests/Api.Tests/Utils/InMemoryData/MemoryCollectionSet.cs
+++ b/tests/Api.Tests/Utils/InMemoryData/MemoryCollectionSet.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
@@ -13,27 +14,75 @@ public class MemoryCollectionSet<T> : IMongoCollectionSet<T>
 
     private IQueryable<T> EntityQueryable => _data.AsQueryable();
 
-    public IEnumerator<T> GetEnumerator() => _data.GetEnumerator();
+    public IEnumerator<T> GetEnumerator()
+    {
+        return _data.GetEnumerator();
+    }
 
-    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 
     public Type ElementType => EntityQueryable.ElementType;
     public Expression Expression => EntityQueryable.Expression;
     public IQueryProvider Provider => EntityQueryable.Provider;
 
     public IMongoCollection<T> Collection => throw new NotImplementedException();
+    public int PendingChanges => 0;
 
-    internal void AddTestData(T item) => _data.Add(item);
+    internal void AddTestData(T item)
+    {
+        _data.Add(item);
+    }
 
-    public Task<T?> Find(string id, CancellationToken cancellationToken) =>
-        Task.FromResult(_data.Find(x => x.Id == id));
+    public Task<T?> Find(string id, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_data.Find(x => x.Id == id));
+    }
 
-    public Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken) =>
-        Task.FromResult(_data.FindAll(i => query.Compile()(i)));
+    public Task<T?> Find(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_data.Find(i => query.Compile()(i)));
+    }
 
-    public void Insert(T item) => throw new NotImplementedException();
+    public Task<List<T>> FindMany(Expression<Func<T, bool>> query, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_data.FindAll(i => query.Compile()(i)));
+    }
 
-    public void Update(T item, string etag) => throw new NotImplementedException();
+    public Task Insert(T item, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
 
-    public Task Save(CancellationToken cancellationToken) => throw new NotImplementedException();
+    [SuppressMessage(
+        "SonarLint",
+        "S2955",
+        Justification = "IEquatable<T> would need to be implemented on every data entity just to stop sonar complaining about a null check. Nope."
+    )]
+    public Task Update(T item, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task Update(List<T> items, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    [SuppressMessage(
+        "SonarLint",
+        "S2955",
+        Justification = "IEquatable<T> would need to be implemented on every data entity just to stop sonar complaining about a null check. Nope."
+    )]
+    public Task Update(T item, string etag, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task PersistAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/tests/Api.Tests/Utils/InMemoryData/MemoryDbContext.cs
+++ b/tests/Api.Tests/Utils/InMemoryData/MemoryDbContext.cs
@@ -19,9 +19,8 @@ public class MemoryDbContext : IDbContext
     public IMongoCollectionSet<ProcessingErrorEntity> ProcessingErrors { get; } =
         new MemoryCollectionSet<ProcessingErrorEntity>();
 
-    public Task SaveChanges(CancellationToken cancellationToken) => throw new NotImplementedException();
-
-    public Task StartTransaction(CancellationToken cancellationToken) => throw new NotImplementedException();
-
-    public Task CommitTransaction(CancellationToken cancellationToken) => throw new NotImplementedException();
+    public Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }


### PR DESCRIPTION
Reverts DEFRA/trade-imports-data-api#198

I want to revert this and introduce more tests for the resource events being raised, then the changes in this PR will be added back in to show now functional change from the state already in prod.