### PR TITLE
CDMS-771 : Conditionality raise error events

### DIFF
--- a/src/Api.Client/Api.Client.csproj
+++ b/src/Api.Client/Api.Client.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Api.Client</PackageId>
-    <VersionPrefix>0.29.0</VersionPrefix>
+    <VersionPrefix>0.30.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Client</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Api/Services/ProcessingErrorService.cs
+++ b/src/Api/Services/ProcessingErrorService.cs
@@ -23,10 +23,13 @@ public class ProcessingErrorService(
 
         await dbContext.SaveChanges(cancellationToken);
 
-        await resourceEventPublisher.Publish(
-            inserted.ToResourceEvent(ResourceEventOperations.Created).WithChangeSet(inserted.ProcessingErrors, []),
-            cancellationToken
-        );
+        if (entity.ProcessingErrors.Any(x => x.Errors.Any(e => e.Code != null)))
+        {
+            await resourceEventPublisher.Publish(
+                inserted.ToResourceEvent(ResourceEventOperations.Created).WithChangeSet(inserted.ProcessingErrors, []),
+                cancellationToken
+            );
+        }
 
         await dbContext.CommitTransaction(cancellationToken);
 
@@ -45,12 +48,15 @@ public class ProcessingErrorService(
 
         await dbContext.SaveChanges(cancellationToken);
 
-        await resourceEventPublisher.Publish(
-            updated
-                .ToResourceEvent(ResourceEventOperations.Updated)
-                .WithChangeSet(updated.ProcessingErrors, existing.ProcessingErrors),
-            cancellationToken
-        );
+        if (entity.ProcessingErrors.Any(x => x.Errors.Any(e => e.Code != null)))
+        {
+            await resourceEventPublisher.Publish(
+                updated
+                    .ToResourceEvent(ResourceEventOperations.Updated)
+                    .WithChangeSet(updated.ProcessingErrors, existing.ProcessingErrors),
+                cancellationToken
+            );
+        }
 
         await dbContext.CommitTransaction(cancellationToken);
 

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Domain</PackageId>
-    <VersionPrefix>0.25.0</VersionPrefix>
+    <VersionPrefix>0.26.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Domain</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Domain/Errors/ErrorItem.cs
+++ b/src/Domain/Errors/ErrorItem.cs
@@ -5,7 +5,7 @@ namespace Defra.TradeImportsDataApi.Domain.Errors;
 public class ErrorItem
 {
     [JsonPropertyName("code")]
-    public string Code { get; set; } = null!;
+    public string? Code { get; set; } = null!;
 
     [JsonPropertyName("message")]
     public string Message { get; set; } = null!;

--- a/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.WhenCreating_ThenUpdating_ShouldEmitResourceEvents_Created.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.WhenCreating_ThenUpdating_ShouldEmitResourceEvents_Created.verified.json
@@ -14,6 +14,12 @@
         "sourceExternalCorrelationId": null,
         "externalVersion": null,
         "created": null,
+        "errors": [
+          {
+            "code": "ALVS01",
+            "message": null
+          }
+        ],
         "message": null
       }
     ]
@@ -24,7 +30,7 @@
     {
       "path": "/0",
       "operation": "Add",
-      "value": "{\n  \"correlationId\": null,\n  \"sourceExternalCorrelationId\": null,\n  \"externalVersion\": null,\n  \"created\": null,\n  \"errors\": [],\n  \"message\": null\n}"
+      "value": "{\n  \"correlationId\": null,\n  \"sourceExternalCorrelationId\": null,\n  \"externalVersion\": null,\n  \"created\": null,\n  \"errors\": [\n    {\n      \"code\": \"ALVS01\",\n      \"message\": null\n    }\n  ],\n  \"message\": null\n}"
     }
   ]
 }

--- a/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.WhenCreating_ThenUpdating_ShouldEmitResourceEvents_Updated.verified.json
+++ b/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.WhenCreating_ThenUpdating_ShouldEmitResourceEvents_Updated.verified.json
@@ -14,6 +14,12 @@
         "sourceExternalCorrelationId": null,
         "externalVersion": null,
         "created": null,
+        "errors": [
+          {
+            "code": "ALVS01",
+            "message": null
+          }
+        ],
         "message": null
       },
       {

--- a/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/ProcessingErrorTests.cs
@@ -58,7 +58,12 @@ public class ProcessingErrorTests(ITestOutputHelper testOutputHelper) : SqsTestB
 
         await DrainAllMessages();
 
-        await client.PutProcessingError(mrn, [new ProcessingError()], null, CancellationToken.None);
+        await client.PutProcessingError(
+            mrn,
+            [new ProcessingError() { Errors = [new ErrorItem() { Code = "ALVS01" }] }],
+            null,
+            CancellationToken.None
+        );
 
         var processingError = await client.GetProcessingError(mrn, CancellationToken.None);
         processingError.Should().NotBeNull();

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -2970,7 +2970,8 @@
         "type": "object",
         "properties": {
           "code": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "message": {
             "type": "string"


### PR DESCRIPTION
Updated API to allow the code on errors to be nullable, and only send out events when at least 1 error with a code exists.