### PR TITLE
CDMS-995 

### DIFF
--- a/src/Api/Services/ResourceEventService.cs
+++ b/src/Api/Services/ResourceEventService.cs
@@ -41,14 +41,11 @@ public class ResourceEventService(
         CancellationToken cancellationToken
     )
     {
-        await dbContext.StartTransaction(cancellationToken);
-
         await resourceEventPublisher.Publish(entity, cancellationToken);
 
         entity = resourceEventRepository.UpdateProcessed(entity);
 
         await dbContext.SaveChanges(cancellationToken);
-        await dbContext.CommitTransaction(cancellationToken);
 
         return entity;
     }

--- a/tests/Api.Tests/Services/ResourceEventServiceTests.cs
+++ b/tests/Api.Tests/Services/ResourceEventServiceTests.cs
@@ -45,11 +45,9 @@ public class ResourceEventServiceTests
 
         await Subject.Publish(entity, CancellationToken.None);
 
-        await DbContext.Received(1).StartTransaction(CancellationToken.None);
         await ResourceEventPublisher.Received(1).Publish(entity, CancellationToken.None);
         ResourceEventRepository.Received(1).UpdateProcessed(Arg.Is<ResourceEventEntity>(x => x.Id == "id"));
         await DbContext.Received(1).SaveChanges(CancellationToken.None);
-        await DbContext.Received(1).CommitTransaction(CancellationToken.None);
     }
 
     [Fact]
@@ -67,11 +65,9 @@ public class ResourceEventServiceTests
 
         await Subject.PublishAllowException(entity, CancellationToken.None);
 
-        await DbContext.Received(1).StartTransaction(CancellationToken.None);
         await ResourceEventPublisher.Received(1).Publish(entity, CancellationToken.None);
         ResourceEventRepository.Received(1).UpdateProcessed(Arg.Is<ResourceEventEntity>(x => x.Id == "id"));
         await DbContext.Received(1).SaveChanges(CancellationToken.None);
-        await DbContext.Received(1).CommitTransaction(CancellationToken.None);
     }
 
     [Fact]


### PR DESCRIPTION
Removed the transaction from updating the resource event, and added a warning to be logged when a message takes more than 750ms