### PR TITLE
CDMS-1040: Change default read write settings coming from the connection string that will apply globally for all of the API

### DIFF
--- a/src/Data/Extensions/MongoClientSettingsExtensions.cs
+++ b/src/Data/Extensions/MongoClientSettingsExtensions.cs
@@ -1,0 +1,34 @@
+using MongoDB.Driver;
+
+namespace Defra.TradeImportsDataApi.Data.Extensions;
+
+public static class MongoClientSettingsExtensions
+{
+    /// <summary>
+    /// Configures the MongoDB client for read-your-writes consistency by:
+    /// - Reading from the primary (ReadPreference.Primary).
+    /// - Acknowledging writes only after a majority of replica set members have replicated the write,
+    ///   optionally waiting for the journal flush on those members (WriteConcern.WMajority with journaling).
+    /// - Reading only majority-committed data (ReadConcern.Majority).
+    ///
+    /// This combination ensures that immediately after a write, later reads from this client
+    /// observe the majority-committed state on the primary, avoiding stale reads from secondaries.
+    /// </summary>
+    /// <param name="settings">The MongoClientSettings to configure.</param>
+    /// <param name="journal">
+    /// When true, requires journaled durability alongside majority replication.
+    /// In modern MongoDB deployments, majority writes are journaled by default; this makes it explicit.
+    /// </param>
+    /// <returns>The configured MongoClientSettings.</returns>
+    public static MongoClientSettings UsePrimaryMajorityConsistency(
+        this MongoClientSettings settings,
+        bool journal = true
+    )
+    {
+        settings.ReadPreference = ReadPreference.Primary;
+        settings.WriteConcern = WriteConcern.WMajority.With(journal: journal);
+        settings.ReadConcern = ReadConcern.Majority;
+
+        return settings;
+    }
+}

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -39,10 +39,7 @@ public static class ServiceCollectionExtensions
             var options =
                 sp.GetService<IOptions<MongoDbOptions>>() ?? throw new InvalidOperationException("Options not found");
             var settings = MongoClientSettings.FromConnectionString(options.Value.DatabaseUri);
-
-            settings.ReadPreference = ReadPreference.Primary;
-            settings.WriteConcern = WriteConcern.WMajority;
-            settings.ReadConcern = ReadConcern.Majority;
+            settings.UsePrimaryMajorityConsistency(journal: true);
 
             if (options.Value.QueryLogging)
             {

--- a/src/Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Data/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,10 @@ public static class ServiceCollectionExtensions
                 sp.GetService<IOptions<MongoDbOptions>>() ?? throw new InvalidOperationException("Options not found");
             var settings = MongoClientSettings.FromConnectionString(options.Value.DatabaseUri);
 
+            settings.ReadPreference = ReadPreference.Primary;
+            settings.WriteConcern = WriteConcern.WMajority;
+            settings.ReadConcern = ReadConcern.Majority;
+
             if (options.Value.QueryLogging)
             {
                 var commandTracker = sp.GetRequiredService<MongoCommandTracker>();

--- a/tests/Api.IntegrationTests/IntegrationTestBase.cs
+++ b/tests/Api.IntegrationTests/IntegrationTestBase.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using Defra.TradeImportsDataApi.Api.Client;
 using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Data.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Conventions;
 using MongoDB.Driver;
@@ -35,6 +36,7 @@ public abstract class IntegrationTestBase
         settings.ServerSelectionTimeout = TimeSpan.FromSeconds(5);
         settings.ConnectTimeout = TimeSpan.FromSeconds(5);
         settings.SocketTimeout = TimeSpan.FromSeconds(5);
+        settings.UsePrimaryMajorityConsistency(journal: true);
 
         return new MongoClient(settings).GetDatabase("trade-imports-data-api");
     }


### PR DESCRIPTION
Please see `UsePrimaryMajorityConsistency` method being added and where it's used.

We see continual examples, albeit potentially small, where updates are made to the data API yet when data is requested, the stale previous version is returned.

These settings aim to combat that problem as we want the data API to always return whatever data has been accepted during a write.