### PR TITLE
CDMS-1042: Only use non-cancelled records for the manual release reporting

### DIFF
--- a/src/Api/Endpoints/Reporting/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/Reporting/EndpointRouteBuilderExtensions.cs
@@ -49,7 +49,12 @@ public static class EndpointRouteBuilderExtensions
         }
 
         var query = dbContext
-            .CustomsDeclarations.Where(x => x.Finalisation!.MessageSentAt >= from && x.Finalisation!.MessageSentAt < to)
+            .CustomsDeclarations.Where(x =>
+                x.Finalisation!.MessageSentAt >= from
+                && x.Finalisation!.MessageSentAt < to
+                && x.Finalisation!.FinalState != "1" // Is not cancelled
+                && x.Finalisation!.FinalState != "2" // Is not cancelled
+            )
             .Select(x => new { x.Id, x.Finalisation!.IsManualRelease });
 
         var dbResult = await query.ToListWithFallbackAsync(cancellationToken);

--- a/tests/Api.Tests/Endpoints/Reporting/GetTests.cs
+++ b/tests/Api.Tests/Endpoints/Reporting/GetTests.cs
@@ -168,6 +168,42 @@ public class GetTests : EndpointTestBase, IClassFixture<WireMockContext>
             }
         );
 
+        customsDeclaration =
+            JsonSerializer.Deserialize<CustomsDeclaration>(body, s_jsonOptions)
+            ?? throw new InvalidOperationException();
+        customsDeclaration.Finalisation!.FinalState = "1";
+        MemoryDbContext.CustomsDeclarations.AddTestData(
+            new CustomsDeclarationEntity
+            {
+                Id = "Mrn4",
+                ClearanceRequest = customsDeclaration.ClearanceRequest,
+                ClearanceDecision = customsDeclaration.ClearanceDecision,
+                Finalisation = customsDeclaration.Finalisation,
+                ExternalErrors = customsDeclaration.ExternalErrors,
+                Created = new DateTime(2025, 4, 3, 10, 0, 0, DateTimeKind.Utc),
+                Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
+                ETag = "etag",
+            }
+        );
+
+        customsDeclaration =
+            JsonSerializer.Deserialize<CustomsDeclaration>(body, s_jsonOptions)
+            ?? throw new InvalidOperationException();
+        customsDeclaration.Finalisation!.FinalState = "2";
+        MemoryDbContext.CustomsDeclarations.AddTestData(
+            new CustomsDeclarationEntity
+            {
+                Id = "Mrn5",
+                ClearanceRequest = customsDeclaration.ClearanceRequest,
+                ClearanceDecision = customsDeclaration.ClearanceDecision,
+                Finalisation = customsDeclaration.Finalisation,
+                ExternalErrors = customsDeclaration.ExternalErrors,
+                Created = new DateTime(2025, 4, 3, 10, 0, 0, DateTimeKind.Utc),
+                Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
+                ETag = "etag",
+            }
+        );
+
         var response = await client.GetAsync(
             TradeImportsDataApi.Testing.Endpoints.Reporting.ManualRelease(
                 DateTime.Parse("2024-02-16", CultureInfo.CurrentCulture).ToUniversalTime(),


### PR DESCRIPTION
Currently the manual release endpoint includes cancelled records in the total count for the manual release report, inflating the value. This excludes records where they have been cancelled.