### PR TITLE
CDMS-1070: Allow searching by GMR ID

### DIFF
--- a/src/Api.Client/Api.Client.csproj
+++ b/src/Api.Client/Api.Client.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackageId>Defra.TradeImportsDataApi.Api.Client</PackageId>
-    <VersionPrefix>0.32.0</VersionPrefix>
+    <VersionPrefix>0.33.0</VersionPrefix>
     <PackageDescription>Defra Trade Imports Data Api Client</PackageDescription>
     <Company>DEFRA</Company>
     <RepositoryUrl>https://github.com/DEFRA/trade-imports-data-api</RepositoryUrl>

--- a/src/Api.Client/RelatedImportDeclarationsRequest.cs
+++ b/src/Api.Client/RelatedImportDeclarationsRequest.cs
@@ -8,5 +8,7 @@ public class RelatedImportDeclarationsRequest
 
     public string? ChedId { get; set; }
 
+    public string? GmrId { get; set; }
+
     public int? MaxLinkDepth { get; set; }
 }

--- a/src/Api/Data/GmrRepository.cs
+++ b/src/Api/Data/GmrRepository.cs
@@ -1,6 +1,8 @@
+using System.Linq.Expressions;
 using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Data.Extensions;
 
 namespace Defra.TradeImportsDataApi.Api.Data;
 
@@ -12,6 +14,11 @@ public class GmrRepository(IDbContext dbContext) : IGmrRepository
             return null;
 
         return await dbContext.Gmrs.Find(id, cancellationToken);
+    }
+
+    public async Task<GmrEntity?> Get(Expression<Func<GmrEntity, bool>> predicate, CancellationToken cancellationToken)
+    {
+        return await dbContext.Gmrs.Where(predicate).FirstOrDefaultWithFallbackAsync(cancellationToken);
     }
 
     public async Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken)

--- a/src/Api/Data/IGmrRepository.cs
+++ b/src/Api/Data/IGmrRepository.cs
@@ -6,6 +6,11 @@ public interface IGmrRepository
 {
     Task<GmrEntity?> Get(string id, CancellationToken cancellationToken);
 
+    Task<GmrEntity?> Get(
+        System.Linq.Expressions.Expression<Func<GmrEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    );
+
     Task<List<GmrEntity>> GetAll(string[] customsDeclarationIds, CancellationToken cancellationToken);
 
     GmrEntity Insert(GmrEntity entity);

--- a/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsRequest.cs
+++ b/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsRequest.cs
@@ -17,6 +17,10 @@ public class RelatedImportDeclarationsRequest
     [Description("Search by CHED ID")]
     public string? ChedId { get; init; }
 
+    [FromQuery(Name = "gmrId")]
+    [Description("Search by GMR ID")]
+    public string? GmrId { get; init; }
+
     [FromQuery(Name = "maxLinkDepth")]
     [Description("Max link depth to follow. Default is 3.")]
     public int? MaxLinkDepth { get; init; } = 3;

--- a/src/Api/Services/GmrService.cs
+++ b/src/Api/Services/GmrService.cs
@@ -14,6 +14,11 @@ public class GmrService(
     public Task<GmrEntity?> GetGmr(string id, CancellationToken cancellationToken) =>
         gmrRepository.Get(id, cancellationToken);
 
+    public Task<GmrEntity?> GetGmr(
+        System.Linq.Expressions.Expression<Func<GmrEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    ) => gmrRepository.Get(predicate, cancellationToken);
+
     public async Task<List<GmrEntity>> GetGmrByChedId(string chedId, CancellationToken cancellationToken)
     {
         var customsDeclarationIdentifier = await importPreNotificationRepository.GetCustomsDeclarationIdentifier(

--- a/src/Api/Services/IGmrService.cs
+++ b/src/Api/Services/IGmrService.cs
@@ -6,6 +6,11 @@ public interface IGmrService
 {
     Task<GmrEntity?> GetGmr(string id, CancellationToken cancellationToken);
 
+    Task<GmrEntity?> GetGmr(
+        System.Linq.Expressions.Expression<Func<GmrEntity, bool>> predicate,
+        CancellationToken cancellationToken
+    );
+
     Task<List<GmrEntity>> GetGmrByChedId(string chedId, CancellationToken cancellationToken);
 
     Task<GmrEntity> Insert(GmrEntity entity, CancellationToken cancellationToken);

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -942,6 +942,15 @@
             }
           },
           {
+            "name": "gmrId",
+            "in": "query",
+            "description": "Search by GMR ID",
+            "schema": {
+              "type": "string",
+              "description": "Search by GMR ID"
+            }
+          },
+          {
             "name": "maxLinkDepth",
             "in": "query",
             "description": "Max link depth to follow. Default is 3.",

--- a/tests/Api.Tests/Services/GmrServiceTests.cs
+++ b/tests/Api.Tests/Services/GmrServiceTests.cs
@@ -177,4 +177,17 @@ public class GmrServiceTests
 
         result.Should().NotBeNull();
     }
+
+    [Fact]
+    public async Task GetGmr_WithPredicate_ShouldReturn()
+    {
+        const string id = "id";
+        GmrRepository
+            .Get(Arg.Any<System.Linq.Expressions.Expression<Func<GmrEntity, bool>>>(), CancellationToken.None)
+            .Returns(new GmrEntity { Id = id, Gmr = new Gmr() });
+
+        var result = await Subject.GetGmr(x => x.Id == id, CancellationToken.None);
+
+        result.Should().NotBeNull();
+    }
 }

--- a/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
+++ b/tests/Api.Tests/Services/RelatedImportDeclarationsServiceTests.cs
@@ -4,6 +4,7 @@ using Defra.TradeImportsDataApi.Api.Services;
 using Defra.TradeImportsDataApi.Api.Tests.Utils.InMemoryData;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Domain.CustomsDeclaration;
+using Defra.TradeImportsDataApi.Domain.Gvms;
 using Defra.TradeImportsDataApi.Domain.Ipaffs;
 using FluentAssertions;
 
@@ -391,6 +392,45 @@ public class RelatedImportDeclarationsServiceTests
         response.ImportPreNotifications.Length.Should().Be(2);
     }
 
+    [Theory]
+    [InlineData("gmr1")]
+    [InlineData("gmr2")]
+    [InlineData("gmr3")]
+    public async Task GivenSearchByGmrId_WhenExists_ThenShouldReturn(string gmrId)
+    {
+        var memoryDbContext = new MemoryDbContext();
+        InsertTestData(memoryDbContext);
+
+        var subject = CreateSubject(memoryDbContext);
+
+        var response = await subject.Search(
+            new RelatedImportDeclarationsRequest { GmrId = gmrId },
+            CancellationToken.None
+        );
+
+        response.Should().NotBeNull();
+        response.CustomsDeclarations.Length.Should().Be(3);
+        response.ImportPreNotifications.Length.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task GivenSearchByGmrId_WhenNotExists_ThenShouldReturnEmpty()
+    {
+        var memoryDbContext = new MemoryDbContext();
+        InsertTestData(memoryDbContext);
+
+        var subject = CreateSubject(memoryDbContext);
+
+        var response = await subject.Search(
+            new RelatedImportDeclarationsRequest { GmrId = "not-exists" },
+            CancellationToken.None
+        );
+
+        response.Should().NotBeNull();
+        response.CustomsDeclarations.Length.Should().Be(0);
+        response.ImportPreNotifications.Length.Should().Be(0);
+    }
+
     private static void InsertTestData(MemoryDbContext memoryDbContext)
     {
         memoryDbContext.ImportPreNotifications.AddTestData(CreateImportPreNotification("CHEDA.GB.2025.1234567"));
@@ -401,6 +441,10 @@ public class RelatedImportDeclarationsServiceTests
         memoryDbContext.CustomsDeclarations.AddTestData(CreateCustomsDeclaration("mrn1", ["1234569", "1234510"]));
         memoryDbContext.CustomsDeclarations.AddTestData(CreateCustomsDeclaration("mrn2", ["1234568", "1234569"]));
         memoryDbContext.CustomsDeclarations.AddTestData(CreateCustomsDeclaration("mrn3", ["1234567", "1234568"]));
+
+        memoryDbContext.Gmrs.AddTestData(CreateGmr("gmr1", ["mrn1", "mrn2"]));
+        memoryDbContext.Gmrs.AddTestData(CreateGmr("gmr2", ["mrn2", "mrn3"]));
+        memoryDbContext.Gmrs.AddTestData(CreateGmr("gmr3", ["mrn1"]));
     }
 
     private static ImportPreNotificationEntity CreateImportPreNotification(string chedId)
@@ -437,11 +481,25 @@ public class RelatedImportDeclarationsServiceTests
         };
     }
 
+    private static GmrEntity CreateGmr(string gmrId, List<string> mrns)
+    {
+        return new GmrEntity
+        {
+            Id = gmrId,
+            CustomsDeclarationIdentifiers = mrns,
+            Gmr = new Gmr(),
+            Created = new DateTime(2025, 4, 3, 10, 0, 0, DateTimeKind.Utc),
+            Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
+            ETag = "etag",
+        };
+    }
+
     private static RelatedImportDeclarationsService CreateSubject(MemoryDbContext memoryDbContext)
     {
         return new RelatedImportDeclarationsService(
             new CustomsDeclarationRepository(memoryDbContext),
-            new ImportPreNotificationRepository(memoryDbContext)
+            new ImportPreNotificationRepository(memoryDbContext),
+            new GmrRepository(memoryDbContext)
         );
     }
 }


### PR DESCRIPTION
This adds the ability for an API client to search for related import declarations by a GMR ID.