### PR TITLE
CDMS-1086: Move fixed 30 day TTL to config option so it can be overridden

### DIFF
--- a/src/Api/Configuration/ResourceEventOptions.cs
+++ b/src/Api/Configuration/ResourceEventOptions.cs
@@ -11,4 +11,7 @@ public class ResourceEventOptions
     public required string TopicName { get; init; }
 
     public string TopicArn => $"{ArnPrefix}:{TopicName}";
+
+    [Range(1, 180)]
+    public int TtlDays { get; init; } = 30;
 }


### PR DESCRIPTION
As per PR title - there is no functional change here.

We allow between 1 and 180 days (6 months).

The default remains at 30 days as it was before.