### PR TITLE
CDMS-670: Don't create a change set when the resource event is being created for a new entity

### DIFF
--- a/src/Api/Services/CustomsDeclarationService.cs
+++ b/src/Api/Services/CustomsDeclarationService.cs
@@ -31,18 +31,17 @@ public class CustomsDeclarationService(
 
         await TrackImportPreNotificationUpdate(inserted, cancellationToken);
 
-        var resourceEvent = inserted
-            .ToResourceEvent(ResourceEventOperations.Created)
-            .WithChangeSet(
-                new CustomsDeclaration
-                {
-                    ClearanceRequest = inserted.ClearanceRequest,
-                    ClearanceDecision = inserted.ClearanceDecision,
-                    Finalisation = inserted.Finalisation,
-                    ExternalErrors = inserted.ExternalErrors,
-                },
-                new CustomsDeclaration()
-            );
+        var resourceEvent = inserted.ToResourceEvent(
+            ResourceEventOperations.Created,
+            new CustomsDeclaration
+            {
+                ClearanceRequest = inserted.ClearanceRequest,
+                ClearanceDecision = inserted.ClearanceDecision,
+                Finalisation = inserted.Finalisation,
+                ExternalErrors = inserted.ExternalErrors,
+            },
+            new CustomsDeclaration()
+        );
 
         var resourceEventEntity = resourceEventRepository.Insert(resourceEvent);
 
@@ -76,24 +75,23 @@ public class CustomsDeclarationService(
 
         await TrackImportPreNotificationUpdate(updated, cancellationToken);
 
-        var resourceEvent = updated
-            .ToResourceEvent(ResourceEventOperations.Updated)
-            .WithChangeSet(
-                new CustomsDeclaration
-                {
-                    ClearanceRequest = updated.ClearanceRequest,
-                    ClearanceDecision = updated.ClearanceDecision,
-                    Finalisation = updated.Finalisation,
-                    ExternalErrors = updated.ExternalErrors,
-                },
-                new CustomsDeclaration
-                {
-                    ClearanceRequest = existing.ClearanceRequest,
-                    ClearanceDecision = existing.ClearanceDecision,
-                    Finalisation = existing.Finalisation,
-                    ExternalErrors = existing.ExternalErrors,
-                }
-            );
+        var resourceEvent = updated.ToResourceEvent(
+            ResourceEventOperations.Updated,
+            new CustomsDeclaration
+            {
+                ClearanceRequest = updated.ClearanceRequest,
+                ClearanceDecision = updated.ClearanceDecision,
+                Finalisation = updated.Finalisation,
+                ExternalErrors = updated.ExternalErrors,
+            },
+            new CustomsDeclaration
+            {
+                ClearanceRequest = existing.ClearanceRequest,
+                ClearanceDecision = existing.ClearanceDecision,
+                Finalisation = existing.Finalisation,
+                ExternalErrors = existing.ExternalErrors,
+            }
+        );
 
         var resourceEventEntity = resourceEventRepository.Insert(resourceEvent);
 

--- a/src/Api/Services/DataEntityExtensions.cs
+++ b/src/Api/Services/DataEntityExtensions.cs
@@ -15,14 +15,17 @@ public static class DataEntityExtensions
         Converters = { new JsonStringEnumConverter() },
     };
 
-    public static ResourceEvent<TDataEntity> ToResourceEvent<TDataEntity>(
+    public static ResourceEvent<TDataEntity> ToResourceEvent<TDataEntity, TDomain>(
         this TDataEntity entity,
         string operation,
+        TDomain current,
+        TDomain previous,
         bool includeEntityAsResource = true
     )
         where TDataEntity : IDataEntity
+        where TDomain : class
     {
-        return new ResourceEvent<TDataEntity>
+        var result = new ResourceEvent<TDataEntity>
         {
             ResourceId = entity.Id,
             ResourceType = ResourceTypeName<TDataEntity>(),
@@ -30,6 +33,8 @@ public static class DataEntityExtensions
             ETag = entity.ETag,
             Resource = includeEntityAsResource ? entity : default,
         };
+
+        return result.WithChangeSet(current, previous);
     }
 
     private static string ResourceTypeName<TDataEntity>()
@@ -46,7 +51,7 @@ public static class DataEntityExtensions
         };
     }
 
-    public static ResourceEvent<TDataEntity> WithChangeSet<TDataEntity, TDomain>(
+    private static ResourceEvent<TDataEntity> WithChangeSet<TDataEntity, TDomain>(
         this ResourceEvent<TDataEntity> @event,
         TDomain current,
         TDomain previous

--- a/src/Api/Services/ImportPreNotificationService.cs
+++ b/src/Api/Services/ImportPreNotificationService.cs
@@ -43,9 +43,11 @@ public class ImportPreNotificationService(
 
         importPreNotificationRepository.TrackImportPreNotificationUpdate(inserted);
 
-        var resourceEvent = inserted
-            .ToResourceEvent(ResourceEventOperations.Created)
-            .WithChangeSet(inserted.ImportPreNotification, new ImportPreNotification());
+        var resourceEvent = inserted.ToResourceEvent(
+            ResourceEventOperations.Created,
+            inserted.ImportPreNotification,
+            new ImportPreNotification()
+        );
 
         var resourceEventEntity = resourceEventRepository.Insert(resourceEvent);
 
@@ -69,9 +71,11 @@ public class ImportPreNotificationService(
 
         importPreNotificationRepository.TrackImportPreNotificationUpdate(updated);
 
-        var resourceEvent = updated
-            .ToResourceEvent(ResourceEventOperations.Updated)
-            .WithChangeSet(updated.ImportPreNotification, existing.ImportPreNotification);
+        var resourceEvent = updated.ToResourceEvent(
+            ResourceEventOperations.Updated,
+            updated.ImportPreNotification,
+            existing.ImportPreNotification
+        );
 
         var resourceEventEntity = resourceEventRepository.Insert(resourceEvent);
 

--- a/src/Api/Services/ProcessingErrorService.cs
+++ b/src/Api/Services/ProcessingErrorService.cs
@@ -21,9 +21,7 @@ public class ProcessingErrorService(
 
         var inserted = processingErrorRepository.Insert(entity);
 
-        var resourceEvent = inserted
-            .ToResourceEvent(ResourceEventOperations.Created)
-            .WithChangeSet(inserted.ProcessingErrors, []);
+        var resourceEvent = inserted.ToResourceEvent(ResourceEventOperations.Created, inserted.ProcessingErrors, []);
 
         var resourceEventEntity = resourceEventRepository.Insert(resourceEvent);
 
@@ -45,9 +43,11 @@ public class ProcessingErrorService(
 
         var (existing, updated) = await processingErrorRepository.Update(entity, etag, cancellationToken);
 
-        var resourceEvent = updated
-            .ToResourceEvent(ResourceEventOperations.Updated)
-            .WithChangeSet(updated.ProcessingErrors, existing.ProcessingErrors);
+        var resourceEvent = updated.ToResourceEvent(
+            ResourceEventOperations.Updated,
+            updated.ProcessingErrors,
+            existing.ProcessingErrors
+        );
 
         var resourceEventEntity = resourceEventRepository.Insert(resourceEvent);
 

--- a/tests/Api.Tests/Services/DataEntityExtensionsTests.cs
+++ b/tests/Api.Tests/Services/DataEntityExtensionsTests.cs
@@ -13,7 +13,7 @@ public class DataEntityExtensionsTests
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };
 
-        var result = subject.ToResourceEvent("operation");
+        var result = subject.ToResourceEvent("operation", new FixtureDomain(), new FixtureDomain());
 
         result.ResourceId.Should().Be("id");
         result.ResourceType.Should().Be("Fixture");
@@ -27,7 +27,12 @@ public class DataEntityExtensionsTests
     {
         var subject = new FixtureEntity { Id = "id", ETag = "etag" };
 
-        var result = subject.ToResourceEvent("operation", includeEntityAsResource: false);
+        var result = subject.ToResourceEvent(
+            "operation",
+            new FixtureDomain(),
+            new FixtureDomain(),
+            includeEntityAsResource: false
+        );
 
         result.Resource.Should().BeNull();
     }
@@ -41,7 +46,7 @@ public class DataEntityExtensionsTests
             ImportPreNotification = new ImportPreNotification(),
         };
 
-        var result = subject.ToResourceEvent("operation");
+        var result = subject.ToResourceEvent("operation", new FixtureDomain(), new FixtureDomain());
 
         result.ResourceType.Should().Be("ImportPreNotification");
     }
@@ -51,7 +56,7 @@ public class DataEntityExtensionsTests
     {
         var subject = new CustomsDeclarationEntity { Id = "id" };
 
-        var result = subject.ToResourceEvent("operation");
+        var result = subject.ToResourceEvent("operation", new FixtureDomain(), new FixtureDomain());
 
         result.ResourceType.Should().Be("CustomsDeclaration");
     }
@@ -61,7 +66,7 @@ public class DataEntityExtensionsTests
     {
         var subject = new ProcessingErrorEntity { Id = "id", ProcessingErrors = [] };
 
-        var result = subject.ToResourceEvent("operation");
+        var result = subject.ToResourceEvent("operation", new FixtureDomain(), new FixtureDomain());
 
         result.ResourceType.Should().Be("ProcessingError");
     }
@@ -83,9 +88,8 @@ public class DataEntityExtensionsTests
             ETag = "etag",
             FixtureType = FixtureType.Value2,
         };
-        var subject = current.ToResourceEvent("operation");
 
-        var act = () => subject.WithChangeSet(current, previous);
+        var act = () => current.ToResourceEvent("operation", current, previous);
 
         act.Should().NotThrow<InvalidOperationException>();
     }
@@ -107,9 +111,7 @@ public class DataEntityExtensionsTests
             ETag = "etag",
             FixtureType = FixtureType.Value2,
         };
-        var subject = current.ToResourceEvent("operation");
-
-        var result = subject.WithChangeSet(current, previous);
+        var result = current.ToResourceEvent("operation", current, previous);
 
         result.ChangeSet.Count.Should().Be(2);
         result.ChangeSet[0].Operation.Should().Be("Replace");
@@ -137,9 +139,7 @@ public class DataEntityExtensionsTests
             ETag = "etag",
             FixtureType = FixtureType.Value1,
         };
-        var subject = current.ToResourceEvent("operation");
-
-        var result = subject.WithChangeSet(current, previous);
+        var result = current.ToResourceEvent("operation", current, previous);
 
         result.SubResourceType.Should().BeNull();
     }
@@ -151,7 +151,7 @@ public class DataEntityExtensionsTests
         var previous = new CustomsDeclaration();
         var current = new CustomsDeclaration { ClearanceRequest = new ClearanceRequest() };
 
-        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+        var result = subject.ToResourceEvent("operation", current, previous);
 
         result.SubResourceType.Should().Be("ClearanceRequest");
     }
@@ -163,7 +163,7 @@ public class DataEntityExtensionsTests
         var previous = new CustomsDeclaration { ClearanceRequest = new ClearanceRequest { ExternalVersion = 1 } };
         var current = new CustomsDeclaration { ClearanceRequest = new ClearanceRequest { ExternalVersion = 2 } };
 
-        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+        var result = subject.ToResourceEvent("operation", current, previous);
 
         result.SubResourceType.Should().Be("ClearanceRequest");
     }
@@ -175,7 +175,7 @@ public class DataEntityExtensionsTests
         var previous = new CustomsDeclaration();
         var current = new CustomsDeclaration { ClearanceDecision = new ClearanceDecision { Items = [] } };
 
-        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+        var result = subject.ToResourceEvent("operation", current, previous);
 
         result.SubResourceType.Should().Be("ClearanceDecision");
     }
@@ -195,7 +195,7 @@ public class DataEntityExtensionsTests
             },
         };
 
-        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+        var result = subject.ToResourceEvent("operation", current, previous);
 
         result.SubResourceType.Should().Be("Finalisation");
     }
@@ -207,7 +207,7 @@ public class DataEntityExtensionsTests
         var previous = new CustomsDeclaration();
         var current = new CustomsDeclaration { ExternalErrors = [new ExternalError()] };
 
-        var result = subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+        var result = subject.ToResourceEvent("operation", current, previous);
 
         result.SubResourceType.Should().Be("ExternalError");
     }
@@ -230,7 +230,7 @@ public class DataEntityExtensionsTests
             ExternalErrors = [],
         };
 
-        var act = () => subject.ToResourceEvent("operation").WithChangeSet(current, previous);
+        var act = () => subject.ToResourceEvent("operation", current, previous);
 
         act.Should().Throw<InvalidOperationException>();
     }
@@ -252,4 +252,8 @@ public class DataEntityExtensionsTests
         Value1,
         Value2,
     }
+
+#pragma warning disable S2094
+    private class FixtureDomain;
+#pragma warning restore S2094
 }


### PR DESCRIPTION
As per PR title.

Change sets should only be produced when an entity is being updated.