### PR TITLE
CDMS-1354: Explicitly return transient pre-notifications in search results

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -17,10 +17,10 @@
   <ItemGroup>
     <PackageReference Include="Amazon.CloudWatch.EMF" Version="2.2.0" />
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.33" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.27" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.37" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.30" />
     <!-- Ensure SecurityToken aligns with AWSSDK.Core 4.x to avoid NU1608 -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.13" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
     <PackageReference Include="Elastic.CommonSchema.Serilog" Version="9.0.0" />
     <PackageReference Include="Elastic.Serilog.Enrichers.Web" Version="9.0.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
@@ -36,6 +36,8 @@
     <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="9.0.6" />
     <PackageReference Include="JsonPath.Net" Version="3.0.2" />
     <PackageReference Include="JsonPatch.Net" Version="5.0.2" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Data\Data.csproj" />

--- a/src/Api/Endpoints/RelatedImportDeclarations/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/RelatedImportDeclarations/EndpointRouteBuilderExtensions.cs
@@ -55,7 +55,14 @@ public static class EndpointRouteBuilderExtensions
                     x.Updated
                 ))
                 .ToArray(),
-            searchResults.Gmrs.Select(x => new GmrResponse(x.Gmr, x.Created, x.Updated)).ToArray()
+            searchResults.Gmrs.Select(x => new GmrResponse(x.Gmr, x.Created, x.Updated)).ToArray(),
+            searchResults
+                .TransientNotifications.Select(x => new ImportPreNotificationResponse(
+                    x.ImportPreNotification,
+                    x.Created,
+                    x.Updated
+                ))
+                .ToArray()
         );
 
         return Results.Ok(response);

--- a/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsResponse.cs
+++ b/src/Api/Endpoints/RelatedImportDeclarations/RelatedImportDeclarationsResponse.cs
@@ -8,5 +8,7 @@ namespace Defra.TradeImportsDataApi.Api.Endpoints.RelatedImportDeclarations;
 public record RelatedImportDeclarationsResponse(
     [property: JsonPropertyName("customsDeclarations")] CustomsDeclarationResponse[] CustomsDeclarations,
     [property: JsonPropertyName("importPreNotifications")] ImportPreNotificationResponse[] ImportPreNotifications,
-    [property: JsonPropertyName("goodsVehicleMovements")] GmrResponse[] GoodsMovements
+    [property: JsonPropertyName("goodsVehicleMovements")] GmrResponse[] GoodsMovements,
+    [property: JsonPropertyName("transitImportPreNotifications")]
+        ImportPreNotificationResponse[] TransitImportPreNotifications
 );

--- a/src/Api/Services/IRelatedImportDeclarationsService.cs
+++ b/src/Api/Services/IRelatedImportDeclarationsService.cs
@@ -8,6 +8,7 @@ public interface IRelatedImportDeclarationsService
     Task<(
         CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications,
-        GmrEntity[] Gmrs
+        GmrEntity[] Gmrs,
+        ImportPreNotificationEntity[] TransientNotifications
     )> Search(RelatedImportDeclarationsRequest request, CancellationToken cancellationToken);
 }

--- a/src/Api/Services/RelatedImportDeclarationsService.cs
+++ b/src/Api/Services/RelatedImportDeclarationsService.cs
@@ -16,7 +16,8 @@ public class RelatedImportDeclarationsService(
     public async Task<(
         CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications,
-        GmrEntity[] Gmrs
+        GmrEntity[] Gmrs,
+        ImportPreNotificationEntity[] TransientNotifications
     )> Search(RelatedImportDeclarationsRequest request, CancellationToken cancellationToken)
     {
         var maxDepth = 3;
@@ -54,14 +55,20 @@ public class RelatedImportDeclarationsService(
             return await StartFromGmrVrnOrTrn(x => x.Tags.Contains(search), cancellationToken);
         }
 
-        return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>([], [], []);
+        return new ValueTuple<
+            CustomsDeclarationEntity[],
+            ImportPreNotificationEntity[],
+            GmrEntity[],
+            ImportPreNotificationEntity[]
+        >([], [], [], []);
     }
 
     [ExcludeFromCodeCoverage]
     private async Task<(
         CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications,
-        GmrEntity[] Gmrs
+        GmrEntity[] Gmrs,
+        ImportPreNotificationEntity[] TransientNotifications
     )> StartFromCustomsDeclaration(
         Expression<Func<CustomsDeclarationEntity, bool>> predicate,
         int maxDepth,
@@ -72,26 +79,26 @@ public class RelatedImportDeclarationsService(
 
         if (customsDeclarations is null || !customsDeclarations.Any())
         {
-            return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>([], [], []);
+            return new ValueTuple<
+                CustomsDeclarationEntity[],
+                ImportPreNotificationEntity[],
+                GmrEntity[],
+                ImportPreNotificationEntity[]
+            >([], [], [], []);
         }
 
         var identifiers = customsDeclarations.SelectMany(x => x.ImportPreNotificationIdentifiers);
         var notifications = await importPreNotificationRepository.GetAll(identifiers.ToArray(), cancellationToken);
 
         //put this line behind a feature flag that needs to be opt-in to
-        var notificationsWithTags = await importPreNotificationRepository.GetAllByTags(
+        var transientNotifications = await importPreNotificationRepository.GetAllByTags(
             customsDeclarations.Select(x => x.Id.ToLower()).ToArray(),
             cancellationToken
         );
 
-        foreach (
-            var notification in notificationsWithTags.Where(notification =>
-                notifications.All(x => x.Id != notification.Id)
-            )
-        )
-        {
-            notifications.Add(notification);
-        }
+        transientNotifications = transientNotifications
+            .Where(notification => notifications.All(x => x.Id != notification.Id))
+            .ToList();
 
         var result = await IncludeIndirectLinks(
             new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[]>(
@@ -106,17 +113,19 @@ public class RelatedImportDeclarationsService(
         var allRelatedCustomsDeclarationIdentifiers = result.CustomsDeclarations.Select(x => x.Id);
         var gmrs = await gmrRepository.GetAll(allRelatedCustomsDeclarationIdentifiers.ToArray(), cancellationToken);
 
-        return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>(
-            result.CustomsDeclarations,
-            result.ImportPreNotifications,
-            gmrs.ToArray()
-        );
+        return new ValueTuple<
+            CustomsDeclarationEntity[],
+            ImportPreNotificationEntity[],
+            GmrEntity[],
+            ImportPreNotificationEntity[]
+        >(result.CustomsDeclarations, result.ImportPreNotifications, gmrs.ToArray(), transientNotifications.ToArray());
     }
 
     private async Task<(
         CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications,
-        GmrEntity[] Gmrs
+        GmrEntity[] Gmrs,
+        ImportPreNotificationEntity[] TransientNotifications
     )> StartFromImportPreNotification(string chedId, int maxDepth, CancellationToken cancellationToken)
     {
         var identifier = ChedReferenceRegexes.DocumentReferenceIdentifier().Match(chedId).Value;
@@ -127,7 +136,12 @@ public class RelatedImportDeclarationsService(
         );
         if (notification == null)
         {
-            return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>([], [], []);
+            return new ValueTuple<
+                CustomsDeclarationEntity[],
+                ImportPreNotificationEntity[],
+                GmrEntity[],
+                ImportPreNotificationEntity[]
+            >([], [], [], []);
         }
 
         var customsDeclarations = await customsDeclarationRepository.GetAll(
@@ -148,23 +162,30 @@ public class RelatedImportDeclarationsService(
         var allRelatedCustomsDeclarationIdentifiers = result.CustomsDeclarations.Select(x => x.Id);
         var gmrs = await gmrRepository.GetAll(allRelatedCustomsDeclarationIdentifiers.ToArray(), cancellationToken);
 
-        return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>(
-            result.CustomsDeclarations,
-            result.ImportPreNotifications,
-            gmrs.ToArray()
-        );
+        return new ValueTuple<
+            CustomsDeclarationEntity[],
+            ImportPreNotificationEntity[],
+            GmrEntity[],
+            ImportPreNotificationEntity[]
+        >(result.CustomsDeclarations, result.ImportPreNotifications, gmrs.ToArray(), []);
     }
 
     private async Task<(
         CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications,
-        GmrEntity[] Gmrs
+        GmrEntity[] Gmrs,
+        ImportPreNotificationEntity[] TransientNotifications
     )> StartFromGmrId(Expression<Func<GmrEntity, bool>> predicate, CancellationToken cancellationToken)
     {
         var gmr = await gmrRepository.Get(predicate, cancellationToken);
         if (gmr == null)
         {
-            return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>([], [], []);
+            return new ValueTuple<
+                CustomsDeclarationEntity[],
+                ImportPreNotificationEntity[],
+                GmrEntity[],
+                ImportPreNotificationEntity[]
+            >([], [], [], []);
         }
 
         var customsDeclarations = await customsDeclarationRepository.GetAll(
@@ -172,23 +193,30 @@ public class RelatedImportDeclarationsService(
             cancellationToken
         );
 
-        return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>(
-            [.. customsDeclarations],
-            [],
-            [gmr]
-        );
+        return new ValueTuple<
+            CustomsDeclarationEntity[],
+            ImportPreNotificationEntity[],
+            GmrEntity[],
+            ImportPreNotificationEntity[]
+        >([.. customsDeclarations], [], [gmr], []);
     }
 
     private async Task<(
         CustomsDeclarationEntity[] CustomsDeclarations,
         ImportPreNotificationEntity[] ImportPreNotifications,
-        GmrEntity[] Gmrs
+        GmrEntity[] Gmrs,
+        ImportPreNotificationEntity[] TransientNotifications
     )> StartFromGmrVrnOrTrn(Expression<Func<GmrEntity, bool>> predicate, CancellationToken cancellationToken)
     {
         var gmrs = await gmrRepository.GetAll(predicate, cancellationToken);
         if (!gmrs.Any())
         {
-            return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>([], [], []);
+            return new ValueTuple<
+                CustomsDeclarationEntity[],
+                ImportPreNotificationEntity[],
+                GmrEntity[],
+                ImportPreNotificationEntity[]
+            >([], [], [], []);
         }
 
         var customsDeclarationIdentifiers = gmrs.SelectMany(x => x.CustomsDeclarationIdentifiers).ToList();
@@ -198,11 +226,12 @@ public class RelatedImportDeclarationsService(
             cancellationToken
         );
 
-        return new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>(
-            [.. customsDeclarations],
-            [],
-            [.. gmrs]
-        );
+        return new ValueTuple<
+            CustomsDeclarationEntity[],
+            ImportPreNotificationEntity[],
+            GmrEntity[],
+            ImportPreNotificationEntity[]
+        >([.. customsDeclarations], [], [.. gmrs], []);
     }
 
     private async Task<(

--- a/src/Data/Data.csproj
+++ b/src/Data/Data.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
     <PackageReference Include="MongoDB.Driver.Authentication.AWS" Version="3.8.0" />
     <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Domain\Domain.csproj" />

--- a/tests/Api.Client.Tests/Api.Client.Tests.csproj
+++ b/tests/Api.Client.Tests/Api.Client.Tests.csproj
@@ -11,10 +11,12 @@
     <!-- Force the package resolution to the version required by Humanizer.Core.af -->
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <!-- Ensure SecurityToken aligns with AWSSDK.Core 4.x to avoid NU1608 -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.13" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
+++ b/tests/Api.IntegrationTests/Api.IntegrationTests.csproj
@@ -15,11 +15,11 @@
     <!-- Force the package resolution to the version required by Humanizer.Core.af -->
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <!-- Ensure SecurityToken aligns with AWSSDK.Core 4.x to avoid NU1608 -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.13" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.25" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.28" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Api.Tests/Api.Tests.csproj
+++ b/tests/Api.Tests/Api.Tests.csproj
@@ -11,11 +11,11 @@
     <!-- Force the package resolution to the version required by Humanizer.Core.af -->
     <PackageReference Include="Humanizer" Version="3.0.10" />
     <!-- Ensure SecurityToken aligns with AWSSDK.Core 4.x to avoid NU1608 -->
-    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.5.13" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Api.Tests/Endpoints/Search/RelatedImportDeclarationsTests.Search_WhenFound_ShouldReturnContent.verified.txt
+++ b/tests/Api.Tests/Endpoints/Search/RelatedImportDeclarationsTests.Search_WhenFound_ShouldReturnContent.verified.txt
@@ -89,5 +89,6 @@
       created: 2025-04-03T10:00:00Z,
       updated: 2025-04-03T10:15:00Z
     }
-  ]
+  ],
+  transitImportPreNotifications: []
 }

--- a/tests/Api.Tests/Endpoints/Search/RelatedImportDeclarationsTests.cs
+++ b/tests/Api.Tests/Endpoints/Search/RelatedImportDeclarationsTests.cs
@@ -52,7 +52,12 @@ public class RelatedImportDeclarationsTests : EndpointTestBase, IClassFixture<Wi
         MockSearchService
             .Search(Arg.Any<RelatedImportDeclarationsRequest>(), Arg.Any<CancellationToken>())
             .Returns(
-                new ValueTuple<CustomsDeclarationEntity[], ImportPreNotificationEntity[], GmrEntity[]>(
+                new ValueTuple<
+                    CustomsDeclarationEntity[],
+                    ImportPreNotificationEntity[],
+                    GmrEntity[],
+                    ImportPreNotificationEntity[]
+                >(
                     [
                         new CustomsDeclarationEntity
                         {
@@ -83,7 +88,8 @@ public class RelatedImportDeclarationsTests : EndpointTestBase, IClassFixture<Wi
                             Updated = new DateTime(2025, 4, 3, 10, 15, 0, DateTimeKind.Utc),
                             ETag = "etag",
                         },
-                    ]
+                    ],
+                    []
                 )
             );
 

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -5117,6 +5117,12 @@
             "items": {
               "$ref": "#/components/schemas/Defra.TradeImportsDataApi.GmrResponse"
             }
+          },
+          "transitImportPreNotifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.ImportPreNotificationResponse"
+            }
           }
         },
         "additionalProperties": false

--- a/tests/Data.Tests/Data.Tests.csproj
+++ b/tests/Data.Tests/Data.Tests.csproj
@@ -8,7 +8,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="SharpCompress" Version="0.48.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Testing/Testing.csproj
+++ b/tests/Testing/Testing.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net.FluentAssertions" Version="2.3.0" />
+    <PackageReference Include="WireMock.Net.FluentAssertions" Version="2.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Verify.Xunit" Version="31.12.5" />


### PR DESCRIPTION
Refines the `RelatedImportDeclarationsService` to differentiate and return import pre-notifications found via tags as a distinct `TransientNotifications` array. This prevents conflating them with directly linked pre-notifications and provides more granular information to consumers of the related import declarations endpoint.

Includes minor AWS SDK and test SDK dependency updates, along with the addition of `Snappier` and `SharpCompress` packages.
