### PR TITLE
CDMS-1533 : Create new Endpoint on the Trade Imports data API for PHA API

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,13 @@
+# Both services run the same image. Defining the build once means it is built once,
+# with the NuGet PAT, instead of the invalid-topic service kicking off a second,
+# arg-less build that fails.
+x-data-api: &data-api
+  image: trade-imports-data-api:local
+  build:
+    args:
+      DEFRA_NUGET_PAT: ${DEFRA_NUGET_PAT}
+    dockerfile: Dockerfile
+
 services:
   mongodb:
     # Initialise a Mongo cluster with a replicaset of 1 node.
@@ -26,10 +36,7 @@ services:
     restart: always
 
   data-api:
-    build:
-      args:
-        DEFRA_NUGET_PAT: ${DEFRA_NUGET_PAT}
-      dockerfile: Dockerfile
+    <<: *data-api
     depends_on:
       mongodb:
         condition: service_healthy
@@ -58,8 +65,7 @@ services:
       start_period: 5s
   
   data-api-invalid-upserts-topic:
-    build:
-      dockerfile: Dockerfile
+    <<: *data-api
     depends_on:
       mongodb:
         condition: service_healthy

--- a/src/Api.Client/Endpoints.cs
+++ b/src/Api.Client/Endpoints.cs
@@ -25,6 +25,20 @@ internal static class Endpoints
 
     public static string TracesChedsByMrn(string mrn) => $"/customs-declarations/{mrn}/traces-cheds";
 
+    public static string TracesChedUpdates(TracesChedUpdatesRequest request)
+    {
+        // Dates must be ISO 8601 UTC, which the reflection based query string builder below cannot produce
+        var query = new List<string> { $"from={request.From:O}", $"to={request.To:O}" };
+
+        if (request.Page is not null)
+            query.Add($"page={request.Page}");
+
+        if (request.PageSize is not null)
+            query.Add($"pageSize={request.PageSize}");
+
+        return $"/traces-ched-updates?{string.Join("&", query)}";
+    }
+
     public static string ProcessingErrors(string mrn) => $"/processing-errors/{mrn}";
 
     public static string RelatedImportDeclarations(RelatedImportDeclarationsRequest request) =>

--- a/src/Api.Client/ITradeImportsDataApiClient.cs
+++ b/src/Api.Client/ITradeImportsDataApiClient.cs
@@ -62,4 +62,9 @@ public interface ITradeImportsDataApiClient
     );
 
     Task<TracesChedsResponse> GetTracesChedsByMrn(string mrn, CancellationToken cancellationToken);
+
+    Task<TracesChedUpdatesResponse> GetTracesChedUpdates(
+        TracesChedUpdatesRequest request,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/Api.Client/TracesChedUpdateResponse.cs
+++ b/src/Api.Client/TracesChedUpdateResponse.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Client;
+
+public record TracesChedUpdateResponse(
+    [property: JsonPropertyName("referenceNumber")] string ReferenceNumber,
+    [property: JsonPropertyName("updated")] DateTime Updated
+);

--- a/src/Api.Client/TracesChedUpdatesRequest.cs
+++ b/src/Api.Client/TracesChedUpdatesRequest.cs
@@ -1,0 +1,12 @@
+namespace Defra.TradeImportsDataApi.Api.Client;
+
+public class TracesChedUpdatesRequest
+{
+    public required DateTime From { get; set; }
+
+    public required DateTime To { get; set; }
+
+    public int? Page { get; set; }
+
+    public int? PageSize { get; set; }
+}

--- a/src/Api.Client/TracesChedUpdatesResponse.cs
+++ b/src/Api.Client/TracesChedUpdatesResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Client;
+
+public record TracesChedUpdatesResponse(
+    [property: JsonPropertyName("tracesChedUpdates")] IReadOnlyList<TracesChedUpdateResponse> TracesChedUpdates,
+    [property: JsonPropertyName("total")] int Total,
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("pageSize")] int PageSize
+);

--- a/src/Api.Client/TradeImportsDataApiClient.cs
+++ b/src/Api.Client/TradeImportsDataApiClient.cs
@@ -141,6 +141,18 @@ public class TradeImportsDataApiClient(HttpClient httpClient) : ITradeImportsDat
         return await Deserialize<TracesChedsResponse>(response, cancellationToken);
     }
 
+    public async Task<TracesChedUpdatesResponse> GetTracesChedUpdates(
+        TracesChedUpdatesRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        var response = await Get(Endpoints.TracesChedUpdates(request), cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        return await Deserialize<TracesChedUpdatesResponse>(response, cancellationToken);
+    }
+
     public async Task<CustomsDeclarationResponse?> GetCustomsDeclaration(
         string mrn,
         CancellationToken cancellationToken

--- a/src/Api/Data/ITracesChedRepository.cs
+++ b/src/Api/Data/ITracesChedRepository.cs
@@ -6,6 +6,8 @@ public interface ITracesChedRepository
 {
     Task<TracesChedEntity?> Get(string id, CancellationToken cancellationToken);
 
+    Task<TracesChedUpdates> GetUpdates(TracesChedUpdateQuery query, CancellationToken cancellationToken = default);
+
     Task<List<TracesChedEntity>> GetAll(string[] ids, CancellationToken cancellationToken);
 
     TracesChedEntity Insert(TracesChedEntity entity);

--- a/src/Api/Data/TracesChedRepository.cs
+++ b/src/Api/Data/TracesChedRepository.cs
@@ -2,6 +2,7 @@ using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 using Defra.TradeImportsDataApi.Data.Extensions;
+using MongoDB.Driver;
 
 namespace Defra.TradeImportsDataApi.Api.Data;
 
@@ -13,6 +14,44 @@ public class TracesChedRepository(IDbContext dbContext) : ITracesChedRepository
             return null;
 
         return await dbContext.TracesCheds.Find(id, cancellationToken);
+    }
+
+    public async Task<TracesChedUpdates> GetUpdates(
+        TracesChedUpdateQuery query,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (query.Page < 1)
+            throw new ArgumentOutOfRangeException(nameof(query), "Page must be greater than 0");
+
+        if (query.PageSize < 1)
+            throw new ArgumentOutOfRangeException(nameof(query), "Page size must be greater than 0");
+
+        // See UpdatesIdx index and field order - any changes should check the query plan used
+        // A TRACES CHED is only ever written by its own PUT and is keyed on the CHED reference,
+        // so unlike import pre-notifications there is already one document per CHED to return
+
+        var filter = Builders<TracesChedEntity>.Filter.And(
+            Builders<TracesChedEntity>.Filter.Gte(x => x.Updated, query.From),
+            Builders<TracesChedEntity>.Filter.Lt(x => x.Updated, query.To)
+        );
+
+        var collection = dbContext.TracesCheds.Collection;
+
+        var updatesTask = collection
+            .Find(filter)
+            // Sort to ensure same order on each query execution
+            .Sort(Builders<TracesChedEntity>.Sort.Ascending(x => x.Updated).Ascending(x => x.Id))
+            .Project(x => new TracesChedUpdate(x.Id, x.Updated))
+            .Skip((query.Page - 1) * query.PageSize)
+            .Limit(query.PageSize)
+            .ToListAsync(cancellationToken);
+
+        var countTask = collection.CountDocumentsAsync(filter, cancellationToken: cancellationToken);
+
+        await Task.WhenAll(updatesTask, countTask);
+
+        return new TracesChedUpdates(await updatesTask, (int)await countTask);
     }
 
     public async Task<List<TracesChedEntity>> GetAll(string[] ids, CancellationToken cancellationToken)

--- a/src/Api/Data/TracesChedUpdate.cs
+++ b/src/Api/Data/TracesChedUpdate.cs
@@ -1,0 +1,3 @@
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public record TracesChedUpdate(string ReferenceNumber, DateTime Updated);

--- a/src/Api/Data/TracesChedUpdateQuery.cs
+++ b/src/Api/Data/TracesChedUpdateQuery.cs
@@ -1,0 +1,3 @@
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public record TracesChedUpdateQuery(DateTime From, DateTime To, int Page = 1, int PageSize = 100);

--- a/src/Api/Data/TracesChedUpdates.cs
+++ b/src/Api/Data/TracesChedUpdates.cs
@@ -1,0 +1,3 @@
+namespace Defra.TradeImportsDataApi.Api.Data;
+
+public record TracesChedUpdates(IReadOnlyList<TracesChedUpdate> Updates, int Total);

--- a/src/Api/Endpoints/TracesChed/EndpointRouteBuilderExtensions.cs
+++ b/src/Api/Endpoints/TracesChed/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Defra.TradeImportsDataApi.Api.Authentication;
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Api.Endpoints.CustomsDeclarations;
 using Defra.TradeImportsDataApi.Api.Exceptions;
 using Defra.TradeImportsDataApi.Api.Extensions;
@@ -50,6 +51,17 @@ public static class EndpointRouteBuilderExtensions
             .ProducesProblem(StatusCodes.Status409Conflict)
             .ProducesProblem(StatusCodes.Status500InternalServerError)
             .RequireAuthorization(PolicyNames.Write);
+
+        app.MapGet("traces-ched-updates/", GetUpdates)
+            .WithName("GetTracesChedUpdates")
+            .WithTags(groupName)
+            .WithSummary("Get TracesChedUpdates")
+            .WithDescription("Get TRACES CHEDs updated between a period of time")
+            .Produces<TracesChedUpdatesResponse>()
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError)
+            .RequireAuthorization(PolicyNames.Read)
+            .AddEndpointFilter<TracesChedUpdatesRequest.TracesChedUpdatesRequestValidator>();
     }
 
     /// <param name="chedId" example="CHEDA.GB.2024.1020304">CHED ID</param>
@@ -160,6 +172,34 @@ public static class EndpointRouteBuilderExtensions
                         customsDeclarationEntity.Updated
                     ))
                     .ToList()
+            )
+        );
+    }
+
+    /// <param name="request"></param>
+    /// <param name="tracesChedService"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet]
+    private static async Task<IResult> GetUpdates(
+        [AsParameters] TracesChedUpdatesRequest request,
+        [FromServices] ITracesChedService tracesChedService,
+        CancellationToken cancellationToken
+    )
+    {
+        var page = request.Page.GetValueOrDefault();
+        var pageSize = request.PageSize.GetValueOrDefault();
+        var result = await tracesChedService.GetUpdates(
+            new TracesChedUpdateQuery(request.From, request.To, page, pageSize),
+            cancellationToken
+        );
+
+        return Results.Ok(
+            new TracesChedUpdatesResponse(
+                result.Updates.Select(x => new TracesChedUpdateResponse(x.ReferenceNumber, x.Updated)).ToList(),
+                result.Total,
+                page,
+                pageSize
             )
         );
     }

--- a/src/Api/Endpoints/TracesChed/TracesChedUpdateResponse.cs
+++ b/src/Api/Endpoints/TracesChed/TracesChedUpdateResponse.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.TracesChed;
+
+public record TracesChedUpdateResponse(
+    [property: JsonPropertyName("referenceNumber")] string ReferenceNumber,
+    [property: JsonPropertyName("updated")] DateTime Updated
+);

--- a/src/Api/Endpoints/TracesChed/TracesChedUpdatesRequest.cs
+++ b/src/Api/Endpoints/TracesChed/TracesChedUpdatesRequest.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+
+// ReSharper disable ClassNeverInstantiated.Global
+// ReSharper disable UnusedMember.Global
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.TracesChed;
+
+public class TracesChedUpdatesRequest
+{
+    private readonly int? _page;
+    private readonly int? _pageSize;
+
+    [Description(
+        "Filter TRACES CHEDs updated at this date and time or after this date and time. "
+            + " Expected value is UTC using format ISO 8601-1:2019"
+    )]
+    [FromQuery(Name = "from")]
+    public DateTime From { get; init; }
+
+    [Description(
+        "Filter TRACES CHEDs updated before this date and time. "
+            + "Expected value is UTC using format ISO 8601-1:2019. Cannot be more than 1 hour of From"
+    )]
+    [FromQuery(Name = "to")]
+    public DateTime To { get; init; }
+
+    [Description("Page number (1-based). Defaults to 1 if not specified.")]
+    [FromQuery(Name = "page")]
+    public int? Page
+    {
+        get => _page ?? 1;
+        init => _page = value;
+    }
+
+    [Description("Number of items per page. Defaults to 100 if not specified. Max of 1000.")]
+    [FromQuery(Name = "pageSize")]
+    public int? PageSize
+    {
+        get => _pageSize ?? 100;
+        init => _pageSize = value;
+    }
+
+    public class TracesChedUpdatesRequestValidator : ValidationEndpointFilter<TracesChedUpdatesRequest>
+    {
+        public TracesChedUpdatesRequestValidator()
+        {
+            RuleFor(x => x.From).Must(x => x.Kind == DateTimeKind.Utc).WithMessage("Must be UTC");
+            RuleFor(x => x.To).Must(x => x.Kind == DateTimeKind.Utc).WithMessage("Must be UTC");
+            RuleFor(x => (x.From - x.To).Duration())
+                .LessThanOrEqualTo(TimeSpan.FromHours(1))
+                .WithName(nameof(To))
+                .WithMessage(
+                    $"Must not be more than {TimeSpan.FromHours(1).Duration().TotalHours} hour(s) of {nameof(From)}"
+                );
+            RuleFor(x => x.Page).GreaterThanOrEqualTo(1);
+            RuleFor(x => x.PageSize).GreaterThanOrEqualTo(1);
+            RuleFor(x => x.PageSize).LessThanOrEqualTo(1000);
+        }
+    }
+}

--- a/src/Api/Endpoints/TracesChed/TracesChedUpdatesResponse.cs
+++ b/src/Api/Endpoints/TracesChed/TracesChedUpdatesResponse.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Defra.TradeImportsDataApi.Api.Endpoints.TracesChed;
+
+public record TracesChedUpdatesResponse(
+    [property: JsonPropertyName("tracesChedUpdates")] IReadOnlyList<TracesChedUpdateResponse> TracesChedUpdates,
+    [property: JsonPropertyName("total")] int Total,
+    [property: JsonPropertyName("page")] int Page,
+    [property: JsonPropertyName("pageSize")] int PageSize
+);

--- a/src/Api/Services/ITracesChedService.cs
+++ b/src/Api/Services/ITracesChedService.cs
@@ -1,3 +1,4 @@
+using Defra.TradeImportsDataApi.Api.Data;
 using Defra.TradeImportsDataApi.Data.Entities;
 
 namespace Defra.TradeImportsDataApi.Api.Services;
@@ -7,6 +8,8 @@ public interface ITracesChedService
     Task<TracesChedEntity?> Get(string chedId, CancellationToken cancellationToken);
 
     Task<List<TracesChedEntity>> GetByMrn(string mrn, CancellationToken cancellationToken);
+
+    Task<TracesChedUpdates> GetUpdates(TracesChedUpdateQuery query, CancellationToken cancellationToken);
 
     Task<TracesChedEntity> Insert(TracesChedEntity entity, CancellationToken cancellationToken);
 

--- a/src/Api/Services/TracesChedService.cs
+++ b/src/Api/Services/TracesChedService.cs
@@ -33,6 +33,9 @@ public class TracesChedService(
         return inserted;
     }
 
+    public async Task<TracesChedUpdates> GetUpdates(TracesChedUpdateQuery query, CancellationToken cancellationToken) =>
+        await tracesChedRepository.GetUpdates(query, cancellationToken);
+
     public async Task<List<TracesChedEntity>> GetByMrn(string mrn, CancellationToken cancellationToken)
     {
         var identifiers = await customsDeclarationRepository.GetAllImportPreNotificationIdentifiers(

--- a/src/Data/Mongo/Migrations/1_0_9_AddTracesChedIndexes.cs
+++ b/src/Data/Mongo/Migrations/1_0_9_AddTracesChedIndexes.cs
@@ -1,0 +1,29 @@
+using AdaskoTheBeAsT.MongoDbMigrations.Abstractions;
+using Defra.TradeImportsDataApi.Data.Entities;
+using MongoDB.Driver;
+using Version = AdaskoTheBeAsT.MongoDbMigrations.Abstractions.Version;
+
+namespace Defra.TradeImportsDataApi.Data.Mongo.Migrations;
+
+public class AddTracesChedIndexes() : BtmsMigration("Add indexes to traces ched collection", new Version(1, 0, 9))
+{
+    public override async Task UpAsync(MigrationContext context)
+    {
+        await CreateIndex(
+            context.Database.GetCollection<TracesChedEntity>(typeof(TracesChedEntity).DataEntityName()),
+            "UpdatedIdx",
+            Builders<TracesChedEntity>
+                // Id is included so the updates query can sort on updated then id without an in memory sort
+                .IndexKeys.Ascending(x => x.Updated)
+                .Ascending(x => x.Id),
+            cancellationToken: context.CancellationToken
+        );
+    }
+
+    public override async Task DownAsync(MigrationContext context)
+    {
+        await context
+            .Database.GetCollection<TracesChedEntity>(typeof(TracesChedEntity).DataEntityName())
+            .Indexes.DropOneAsync("UpdatedIdx", context.CancellationToken);
+    }
+}

--- a/tests/Api.Client.Tests/Endpoints/TracesCheds/GetUpdatesTests.GetTracesChedUpdates_WhenFound_ShouldReturnUpdates.verified.txt
+++ b/tests/Api.Client.Tests/Endpoints/TracesCheds/GetUpdatesTests.GetTracesChedUpdates_WhenFound_ShouldReturnUpdates.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  TracesChedUpdates: [
+    {
+      ReferenceNumber: CHEDA.GB.2026.1234567,
+      Updated: 2025-05-21 08:15 Utc
+    }
+  ],
+  Total: 1,
+  Page: 1,
+  PageSize: 10
+}

--- a/tests/Api.Client.Tests/Endpoints/TracesCheds/GetUpdatesTests.cs
+++ b/tests/Api.Client.Tests/Endpoints/TracesCheds/GetUpdatesTests.cs
@@ -1,0 +1,80 @@
+using Argon;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace Defra.TradeImportsDataApi.Api.Client.Tests.Endpoints.TracesCheds;
+
+public class GetUpdatesTests : WireMockTestBase<WireMockContext>
+{
+    private TradeImportsDataApiClient Subject { get; }
+
+    private readonly VerifySettings _settings;
+
+    public GetUpdatesTests(WireMockContext context)
+        : base(context)
+    {
+        Subject = new TradeImportsDataApiClient(context.HttpClient);
+
+        _settings = new VerifySettings();
+        _settings.DontScrubGuids();
+        _settings.DontScrubDateTimes();
+        _settings.AddExtraSettings(settings => settings.DefaultValueHandling = DefaultValueHandling.Include);
+    }
+
+    [Fact]
+    public async Task GetTracesChedUpdates_WhenFound_ShouldReturnUpdates()
+    {
+        var from = new DateTime(2025, 5, 21, 8, 0, 0, DateTimeKind.Utc);
+        var to = from.AddHours(1);
+
+        WireMock
+            .Given(
+                Request
+                    .Create()
+                    .WithPath("/traces-ched-updates")
+                    .WithParam("from", $"{from:O}")
+                    .WithParam("to", $"{to:O}")
+                    .WithParam("page", "1")
+                    .WithParam("pageSize", "10")
+                    .UsingGet()
+            )
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithBody(
+                        JsonSerializer.Serialize(
+                            new Defra.TradeImportsDataApi.Api.Endpoints.TracesChed.TracesChedUpdatesResponse(
+                                [
+                                    new Defra.TradeImportsDataApi.Api.Endpoints.TracesChed.TracesChedUpdateResponse(
+                                        "CHEDA.GB.2026.1234567",
+                                        from.AddMinutes(15)
+                                    ),
+                                ],
+                                Total: 1,
+                                Page: 1,
+                                PageSize: 10
+                            )
+                        )
+                    )
+                    .WithStatusCode(StatusCodes.Status200OK)
+            );
+
+        var result = await Subject.GetTracesChedUpdates(
+            new TracesChedUpdatesRequest
+            {
+                From = from,
+                To = to,
+                Page = 1,
+                PageSize = 10,
+            },
+            CancellationToken.None
+        );
+
+        result.Should().NotBeNull();
+        await Verify(result, _settings);
+    }
+}

--- a/tests/Api.IntegrationTests/Endpoints/TracesChedUpdateTests.cs
+++ b/tests/Api.IntegrationTests/Endpoints/TracesChedUpdateTests.cs
@@ -1,0 +1,160 @@
+using Defra.TradeImportsDataApi.Api.Client;
+using Defra.TradeImportsDataApi.Data.Entities;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+using MongoDB.Driver;
+using Trade.Gateway.Api.Contract.Certificate;
+
+namespace Defra.TradeImportsDataApi.Api.IntegrationTests.Endpoints;
+
+public class TracesChedUpdateTests : IntegrationTestBase, IAsyncLifetime
+{
+    public required IMongoCollection<TracesChedEntity> TracesCheds { get; set; }
+    public required TradeImportsDataApiClient DataApiClient { get; set; }
+
+    private DateTime _from;
+
+    public async Task InitializeAsync()
+    {
+        TracesCheds = GetMongoCollection<TracesChedEntity>();
+
+        await TracesCheds.DeleteManyAsync(FilterDefinition<TracesChedEntity>.Empty);
+
+        DataApiClient = CreateDataApiClient();
+
+        // Records are stamped with UtcNow on write, so anchor the window just before the test writes anything
+        _from = DateTime.UtcNow.AddSeconds(-1);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task WhenChedCreated_ThenChedRefAndUpdatedAsExpected()
+    {
+        var chedRef = ImportPreNotificationIdGenerator.Generate();
+
+        await CreateChed(chedRef);
+
+        var ched = await DataApiClient.GetTracesChed(chedRef, CancellationToken.None);
+
+        var result = await GetUpdates();
+
+        result.Total.Should().Be(1);
+        result.TracesChedUpdates.Should().HaveCount(1);
+        result.TracesChedUpdates[0].ReferenceNumber.Should().Be(chedRef);
+        result.TracesChedUpdates[0].Updated.Should().Be(ched!.Updated);
+    }
+
+    [Fact]
+    public async Task WhenChedUpdated_ThenLatestUpdatedReturnedOnce()
+    {
+        var chedRef = ImportPreNotificationIdGenerator.Generate();
+
+        await CreateChed(chedRef);
+        var created = await DataApiClient.GetTracesChed(chedRef, CancellationToken.None);
+
+        await Task.Delay(1);
+        await UpdateChed(chedRef, created!.ETag);
+        var updated = await DataApiClient.GetTracesChed(chedRef, CancellationToken.None);
+
+        var result = await GetUpdates();
+
+        // The CHED reference is the document id, so an update replaces rather than adds a row
+        result.Total.Should().Be(1);
+        result.TracesChedUpdates.Should().HaveCount(1);
+        result.TracesChedUpdates[0].ReferenceNumber.Should().Be(chedRef);
+        result.TracesChedUpdates[0].Updated.Should().Be(updated!.Updated);
+        updated.Updated.Should().BeAfter(created.Updated);
+    }
+
+    [Fact]
+    public async Task WhenChedUpdatedOutsideOfWindow_ThenNotReturned()
+    {
+        var chedRef = ImportPreNotificationIdGenerator.Generate();
+
+        await CreateChed(chedRef);
+
+        var result = await GetUpdates(from: _from.AddMinutes(-30), to: _from.AddMinutes(-29));
+
+        result.Total.Should().Be(0);
+        result.TracesChedUpdates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenPaging_ThenPagesReturnedAsExpected()
+    {
+        const int total = 12;
+        const int pageSize = 5;
+
+        for (var i = 1; i <= total; i++)
+        {
+            await CreateChed($"CHEDA.GB.2025.{i.ToString().PadLeft(7, '0')}");
+            await Task.Delay(1);
+        }
+
+        for (var page = 1; page <= 3; page++)
+        {
+            var result = await GetUpdates(page: page, pageSize: pageSize);
+
+            result.Total.Should().Be(total);
+            result.Page.Should().Be(page);
+            result.PageSize.Should().Be(pageSize);
+
+            var lastPage = page == 3;
+            result.TracesChedUpdates.Should().HaveCount(lastPage ? 2 : pageSize);
+
+            var pageOffset = (page - 1) * pageSize;
+
+            for (var i = 1; i <= result.TracesChedUpdates.Count; i++)
+            {
+                result
+                    .TracesChedUpdates[i - 1]
+                    .ReferenceNumber.Should()
+                    .Be($"CHEDA.GB.2025.{(i + pageOffset).ToString().PadLeft(7, '0')}");
+            }
+        }
+    }
+
+    private async Task CreateChed(string chedRef) =>
+        await DataApiClient.PutTracesChed(
+            chedRef,
+            new DefraUNVTDCHEDProfile
+            {
+                ExchangedDocument = new ExchangedDocument { Identifier = chedRef },
+                SpecifiedConsignment = new Consignment(),
+                Model = "Test",
+            },
+            null,
+            CancellationToken.None
+        );
+
+    private async Task UpdateChed(string chedRef, string? etag) =>
+        await DataApiClient.PutTracesChed(
+            chedRef,
+            new DefraUNVTDCHEDProfile
+            {
+                ExchangedDocument = new ExchangedDocument { Identifier = chedRef },
+                SpecifiedConsignment = new Consignment(),
+                Model = "Test1",
+            },
+            etag,
+            CancellationToken.None
+        );
+
+    private async Task<TracesChedUpdatesResponse> GetUpdates(
+        DateTime? from = null,
+        DateTime? to = null,
+        int? page = null,
+        int? pageSize = null
+    ) =>
+        await DataApiClient.GetTracesChedUpdates(
+            new TracesChedUpdatesRequest
+            {
+                From = from ?? _from,
+                To = to ?? _from.AddHours(1),
+                Page = page,
+                PageSize = pageSize,
+            },
+            CancellationToken.None
+        );
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_FromAndToGreaterThanOneHour_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_FromAndToGreaterThanOneHour_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    To: [
+      Must not be more than 1 hour(s) of From
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_NoFromDate_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_NoFromDate_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: Bad Request,
+  status: 400,
+  detail: Required parameter "DateTime From" was not provided from query string.,
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_NoToDate_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_NoToDate_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,7 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: Bad Request,
+  status: 400,
+  detail: Required parameter "DateTime To" was not provided from query string.,
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_PageLessThan1_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_PageLessThan1_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    Page: [
+      'Page' must be greater than or equal to '1'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeGreaterThan1000_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeGreaterThan1000_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    PageSize: [
+      'Page Size' must be less than or equal to '1000'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeLessThan1_ShouldBeBadRequest.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenInvalidRequest_PageSizeLessThan1_ShouldBeBadRequest.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  type: https://tools.ietf.org/html/rfc9110#section-15.5.1,
+  title: One or more validation errors occurred.,
+  status: 400,
+  errors: {
+    PageSize: [
+      'Page Size' must be greater than or equal to '1'.
+    ]
+  },
+  traceId: {Scrubbed}
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.Get_WhenValidRequest_ShouldReturnSingle.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  tracesChedUpdates: [
+    {
+      referenceNumber: CHEDPP.GB.2024.5194492,
+      updated: 2025-05-21T08:51:00Z
+    }
+  ],
+  total: 1,
+  page: 1,
+  pageSize: 10
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.cs
+++ b/tests/Api.Tests/Endpoints/TracesCheds/GetUpdatesTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using Defra.TradeImportsDataApi.Api.Data;
+using Defra.TradeImportsDataApi.Api.Services;
+using Defra.TradeImportsDataApi.Testing;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using WireMock.Server;
+using Xunit.Abstractions;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Endpoints.TracesCheds;
+
+public class GetUpdatesTests : EndpointTestBase, IClassFixture<WireMockContext>
+{
+    private ITracesChedService MockTracesChedService { get; } = Substitute.For<ITracesChedService>();
+    private WireMockServer WireMock { get; }
+    private readonly VerifySettings _settings;
+
+    public GetUpdatesTests(ApiWebApplicationFactory factory, ITestOutputHelper outputHelper, WireMockContext context)
+        : base(factory, outputHelper)
+    {
+        WireMock = context.Server;
+        WireMock.Reset();
+
+        _settings = new VerifySettings();
+        _settings.ScrubMember("traceId");
+        _settings.DontScrubDateTimes();
+        _settings.DontScrubGuids();
+        _settings.DontIgnoreEmptyCollections();
+    }
+
+    protected override void ConfigureTestServices(IServiceCollection services)
+    {
+        base.ConfigureTestServices(services);
+
+        services.AddTransient<ITracesChedService>(_ => MockTracesChedService);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_NoFromDate_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates());
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_NoToDate_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates(
+                EndpointQuery.New.Where(EndpointFilter.From(DateTime.UtcNow))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_FromAndToGreaterThanOneHour_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 55, 1, DateTimeKind.Utc)))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_PageLessThan1_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 15, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.Page(0))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_PageSizeLessThan1_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 15, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.Page(1))
+                    .Where(EndpointFilter.PageSize(0))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenInvalidRequest_PageSizeGreaterThan1000_ShouldBeBadRequest()
+    {
+        var client = CreateClient();
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.To(new DateTime(2025, 5, 28, 14, 15, 0, DateTimeKind.Utc)))
+                    .Where(EndpointFilter.Page(1))
+                    .Where(EndpointFilter.PageSize(1001))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenValidRequest_ShouldReturnSingle()
+    {
+        var client = CreateClient();
+        var from = new DateTime(2025, 5, 21, 8, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2025, 5, 21, 9, 0, 0, DateTimeKind.Utc);
+        const int page = 1;
+        const int pageSize = 10;
+        MockTracesChedService
+            .GetUpdates(
+                Arg.Is<TracesChedUpdateQuery>(query =>
+                    query!.From == from && query.To == to && query.Page == page && query.PageSize == pageSize
+                ),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(
+                new TracesChedUpdates(
+                    [
+                        new TracesChedUpdate(
+                            "CHEDPP.GB.2024.5194492",
+                            new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc)
+                        ),
+                    ],
+                    Total: 1
+                )
+            );
+
+        var response = await client.GetAsync(
+            TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates(
+                EndpointQuery
+                    .New.Where(EndpointFilter.From(from))
+                    .Where(EndpointFilter.To(to))
+                    .Where(EndpointFilter.Page(page))
+                    .Where(EndpointFilter.PageSize(pageSize))
+            )
+        );
+
+        await VerifyJson(await response.Content.ReadAsStringAsync(), _settings);
+    }
+
+    [Fact]
+    public async Task Get_WhenUnauthorized_ShouldBeUnauthorized()
+    {
+        var client = CreateClient(addDefaultAuthorizationHeader: false);
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Get_WhenWriteOnly_ShouldBeForbidden()
+    {
+        var client = CreateClient(testUser: TestUser.WriteOnly);
+
+        var response = await client.GetAsync(TradeImportsDataApi.Testing.Endpoints.TracesCheds.GetUpdates());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}

--- a/tests/Api.Tests/Endpoints/TracesCheds/TracesChedUpdatesRequestTests.cs
+++ b/tests/Api.Tests/Endpoints/TracesCheds/TracesChedUpdatesRequestTests.cs
@@ -1,0 +1,63 @@
+using Defra.TradeImportsDataApi.Api.Endpoints.TracesChed;
+using FluentAssertions;
+
+namespace Defra.TradeImportsDataApi.Api.Tests.Endpoints.TracesCheds;
+
+public class TracesChedUpdatesRequestTests
+{
+    [Fact]
+    public void WhenPageNotSpecified_ShouldDefault()
+    {
+        var subject = new TracesChedUpdatesRequest();
+
+        subject.Page.Should().Be(1);
+        subject.PageSize.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task WhenFromAndToAreMoreThanOneHourApart_ShouldBeInvalid()
+    {
+        var subject = new TracesChedUpdatesRequest
+        {
+            From = new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc),
+            To = new DateTime(2025, 5, 28, 14, 55, 1, DateTimeKind.Utc),
+        };
+
+        var result = await new TracesChedUpdatesRequest.TracesChedUpdatesRequestValidator().ValidateAsync(subject);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(1);
+        result.Errors.Should().Contain(x => x.ErrorMessage == "Must not be more than 1 hour(s) of From");
+    }
+
+    [Fact]
+    public async Task WhenFromAndToAreAnOneHourApart_ShouldBeValid()
+    {
+        var subject = new TracesChedUpdatesRequest
+        {
+            From = new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Utc),
+            To = new DateTime(2025, 5, 28, 14, 55, 0, DateTimeKind.Utc),
+        };
+
+        var result = await new TracesChedUpdatesRequest.TracesChedUpdatesRequestValidator().ValidateAsync(subject);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task WhenFromAndToNotUtc_ShouldBeInvalid()
+    {
+        var subject = new TracesChedUpdatesRequest
+        {
+            From = new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Unspecified),
+            To = new DateTime(2025, 5, 28, 13, 55, 0, DateTimeKind.Unspecified),
+        };
+
+        var result = await new TracesChedUpdatesRequest.TracesChedUpdatesRequestValidator().ValidateAsync(subject);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Count.Should().Be(2);
+        result.Errors.Should().Contain(x => x.PropertyName == "From" && x.ErrorMessage == "Must be UTC");
+        result.Errors.Should().Contain(x => x.PropertyName == "To" && x.ErrorMessage == "Must be UTC");
+    }
+}

--- a/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
+++ b/tests/Api.Tests/OpenApi/OpenApiTests.OpenApi_VerifyAsExpected.verified.txt
@@ -1255,6 +1255,92 @@
           }
         }
       }
+    },
+    "/traces-ched-updates": {
+      "get": {
+        "tags": [
+          "TracesCheds"
+        ],
+        "summary": "Get TracesChedUpdates",
+        "description": "Get TRACES CHEDs updated between a period of time",
+        "operationId": "GetTracesChedUpdates",
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Filter TRACES CHEDs updated at this date and time or after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter TRACES CHEDs updated at this date and time or after this date and time.  Expected value is UTC using format ISO 8601-1:2019",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "Filter TRACES CHEDs updated before this date and time. Expected value is UTC using format ISO 8601-1:2019. Cannot be more than 1 hour of From",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter TRACES CHEDs updated before this date and time. Expected value is UTC using format ISO 8601-1:2019. Cannot be more than 1 hour of From",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (1-based). Defaults to 1 if not specified.",
+            "schema": {
+              "type": "integer",
+              "description": "Page number (1-based). Defaults to 1 if not specified.",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page. Defaults to 100 if not specified. Max of 1000.",
+            "schema": {
+              "type": "integer",
+              "description": "Number of items per page. Defaults to 100 if not specified. Max of 1000.",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Defra.TradeImportsDataApi.TracesChedUpdatesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -5586,6 +5672,43 @@
           "updated": {
             "type": "string",
             "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.TracesChedUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "referenceNumber": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Defra.TradeImportsDataApi.TracesChedUpdatesResponse": {
+        "type": "object",
+        "properties": {
+          "tracesChedUpdates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Defra.TradeImportsDataApi.TracesChedUpdateResponse"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false

--- a/tests/Api.Tests/Services/TracesChedServiceTests.cs
+++ b/tests/Api.Tests/Services/TracesChedServiceTests.cs
@@ -167,6 +167,24 @@ public class TracesChedServiceTests
     }
 
     [Fact]
+    public async Task GetUpdates_ShouldReturn()
+    {
+        var query = new TracesChedUpdateQuery(
+            new DateTime(2025, 5, 21, 8, 0, 0, DateTimeKind.Utc),
+            new DateTime(2025, 5, 21, 9, 0, 0, DateTimeKind.Utc)
+        );
+        var updates = new TracesChedUpdates(
+            [new TracesChedUpdate("CHEDA.GB.2026.1234567", new DateTime(2025, 5, 21, 8, 51, 0, DateTimeKind.Utc))],
+            Total: 1
+        );
+        TracesChedRepository.GetUpdates(query, CancellationToken.None).Returns(updates);
+
+        var result = await Subject.GetUpdates(query, CancellationToken.None);
+
+        result.Should().BeSameAs(updates);
+    }
+
+    [Fact]
     public async Task GetChedByMrn_ShouldReturn()
     {
         const string id = "id";

--- a/tests/Testing/Endpoints.cs
+++ b/tests/Testing/Endpoints.cs
@@ -42,6 +42,8 @@ public static class Endpoints
         public static string Put(string chedId) => $"{Root}/{chedId}";
 
         public static string GetCustomsDeclarations(string chedId) => $"{Root}/{chedId}/customs-declarations";
+
+        public static string GetUpdates(EndpointQuery? query = null) => $"/traces-ched-updates{query}";
     }
 
     public static class CustomsDeclarations


### PR DESCRIPTION
Adds `GET /traces-ched-updates` so consumers can poll for TRACES CHEDs changed within a time window. Mirrors the existing `GET /import-pre-notification-updates` contract.

`GET /traces-ched-updates?from=&to=&page=&pageSize=`

```
{ "tracesChedUpdates": [ { "referenceNumber": "...", "updated": "..." } ],
"total": 1, "page": 1, "pageSize": 100 }
```

`from`/`to` must be UTC and no more than 1 hour apart. `pageSize` is 1–1000,
default 100. Requires the `read` scope.

- Migration `1.0.9` adds `UpdatesIdx` on `TracesChed` `{updated, _id}`
- `Api.Client` gains `GetTracesChedUpdates`
- Fixes `data-api-invalid-upserts-topic` in `compose.yml`, which built twice and without the NuGet PAT
